### PR TITLE
Remove byteorder-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,6 @@ edition = "2018"
 name = "benchmarks"
 harness = false
 
-[dependencies]
-byteorder = "1.2.6"
-
 [dev-dependencies]
 criterion = "0.2"
 rand = "0.6.1"

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,7 +1,6 @@
 use crate::{tables, Config, STANDARD};
-use byteorder::{BigEndian, ByteOrder};
 
-use std::{error, fmt, str};
+use std::{error, fmt, io::Write, str};
 
 // decode logic operates on chunks of 8 input bytes without padding
 const INPUT_CHUNK_LEN: usize = 8;
@@ -507,8 +506,7 @@ fn decode_chunk(
     }
     accum |= (morsel as u64) << 16;
 
-    BigEndian::write_u64(output, accum);
-
+    (&mut *output).write_all(&accum.to_be_bytes()).unwrap();
     Ok(())
 }
 

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1,5 +1,5 @@
 use crate::{chunked_encoder, Config, STANDARD};
-use byteorder::{BigEndian, ByteOrder};
+use std::convert::TryInto;
 
 ///Encode arbitrary octets as base64.
 ///Returns a String.
@@ -183,7 +183,7 @@ pub fn encode_to_slice(input: &[u8], output: &mut [u8], encode_table: &[u8; 64])
             // Plus, single-digit percentage performance differences might well be quite different
             // on different hardware.
 
-            let input_u64 = BigEndian::read_u64(&input_chunk[0..]);
+            let input_u64 = u64::from_be_bytes(input_chunk[0..8].try_into().unwrap());
 
             output_chunk[0] = encode_table[((input_u64 >> 58) & LOW_SIX_BITS) as usize];
             output_chunk[1] = encode_table[((input_u64 >> 52) & LOW_SIX_BITS) as usize];
@@ -194,7 +194,7 @@ pub fn encode_to_slice(input: &[u8], output: &mut [u8], encode_table: &[u8; 64])
             output_chunk[6] = encode_table[((input_u64 >> 22) & LOW_SIX_BITS) as usize];
             output_chunk[7] = encode_table[((input_u64 >> 16) & LOW_SIX_BITS) as usize];
 
-            let input_u64 = BigEndian::read_u64(&input_chunk[6..]);
+            let input_u64 = u64::from_be_bytes(input_chunk[6..6 + 8].try_into().unwrap());
 
             output_chunk[8] = encode_table[((input_u64 >> 58) & LOW_SIX_BITS) as usize];
             output_chunk[9] = encode_table[((input_u64 >> 52) & LOW_SIX_BITS) as usize];
@@ -205,7 +205,7 @@ pub fn encode_to_slice(input: &[u8], output: &mut [u8], encode_table: &[u8; 64])
             output_chunk[14] = encode_table[((input_u64 >> 22) & LOW_SIX_BITS) as usize];
             output_chunk[15] = encode_table[((input_u64 >> 16) & LOW_SIX_BITS) as usize];
 
-            let input_u64 = BigEndian::read_u64(&input_chunk[12..]);
+            let input_u64 = u64::from_be_bytes(input_chunk[12..12 + 8].try_into().unwrap());
 
             output_chunk[16] = encode_table[((input_u64 >> 58) & LOW_SIX_BITS) as usize];
             output_chunk[17] = encode_table[((input_u64 >> 52) & LOW_SIX_BITS) as usize];
@@ -216,7 +216,7 @@ pub fn encode_to_slice(input: &[u8], output: &mut [u8], encode_table: &[u8; 64])
             output_chunk[22] = encode_table[((input_u64 >> 22) & LOW_SIX_BITS) as usize];
             output_chunk[23] = encode_table[((input_u64 >> 16) & LOW_SIX_BITS) as usize];
 
-            let input_u64 = BigEndian::read_u64(&input_chunk[18..]);
+            let input_u64 = u64::from_be_bytes(input_chunk[18..18 + 8].try_into().unwrap());
 
             output_chunk[24] = encode_table[((input_u64 >> 58) & LOW_SIX_BITS) as usize];
             output_chunk[25] = encode_table[((input_u64 >> 52) & LOW_SIX_BITS) as usize];


### PR DESCRIPTION
This removes the `byteorder`-dependency, which is unneeded in recent stable rust and is pulled in *a lot* via `base64`. 

Notice that the `.unwrap()`s reflect the previous behavior, as `byteorder` would panic implicitly in the same situations.