### PR TITLE
Advertise that unsafe code is forbidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [base64](https://crates.io/crates/base64)
 ===
 
-[![](https://img.shields.io/crates/v/base64.svg)](https://crates.io/crates/base64) [![Docs](https://docs.rs/base64/badge.svg)](https://docs.rs/base64) [![Build](https://travis-ci.org/marshallpierce/rust-base64.svg?branch=master)](https://travis-ci.org/marshallpierce/rust-base64) [![codecov](https://codecov.io/gh/marshallpierce/rust-base64/branch/master/graph/badge.svg)](https://codecov.io/gh/marshallpierce/rust-base64)
+[![](https://img.shields.io/crates/v/base64.svg)](https://crates.io/crates/base64) [![Docs](https://docs.rs/base64/badge.svg)](https://docs.rs/base64) [![Build](https://travis-ci.org/marshallpierce/rust-base64.svg?branch=master)](https://travis-ci.org/marshallpierce/rust-base64) [![codecov](https://codecov.io/gh/marshallpierce/rust-base64/branch/master/graph/badge.svg)](https://codecov.io/gh/marshallpierce/rust-base64) [![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 
 <a href="https://www.jetbrains.com/?from=rust-base64"><img src="/icon_CLion.svg" height="40px"/></a>
 


### PR DESCRIPTION
Having zero unsafe code and forbidding it is a desirable property for Rust code. This commit adds a badge to advertise this property. This helps users make a more informed choice when picking a crate for base64 encoding/decoding.

In this PR clicking the badge leads to the Rust Secure Code WG coordination repo for removing unnecessary unsafe code from the Rust ecosystem. I'm fine with making the link lead somewhere else or making the badge non-clickable if you prefer.