### PR TITLE
Eliminated a call to encoded_size function

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -47,8 +47,7 @@ pub fn encode_config<T: ?Sized + AsRef<[u8]>>(input: &T, config: Config) -> Stri
         None => panic!("integer overflow when calculating buffer size"),
     };
 
-    let encoded_len = encode_config_slice(input.as_ref(), config, &mut buf[..]);
-    debug_assert_eq!(encoded_len, buf.len());
+    encode_with_padding(input.as_ref(), config, buf.len(), &mut buf[..]);
 
     String::from_utf8(buf).expect("Invalid UTF8")
 }


### PR DESCRIPTION
The encode_config function called encode_config_slice which in turn
called encode_with_padding. Both encode_config and encode_config_slice
called encoded_size resulting in encoded_size being called twice. This
commit changes the encode_config function to directly call the
encode_with_padding function, saving one call to encoded_size.