### PR TITLE
Replace "cfg(test)" with "cfg(doctest)" for readme testing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,11 +76,11 @@ extern crate alloc;
 #[cfg(any(feature = "std", test))]
 extern crate std as alloc;
 
-#[cfg(test)]
+#[cfg(doctest)]
 #[macro_use]
 extern crate doc_comment;
 
-#[cfg(test)]
+#[cfg(doctest)]
 doctest!("../README.md");
 
 mod chunked_encoder;


### PR DESCRIPTION
Rustdoc now passes "doctest" when running in test mode.