### PR TITLE
Remove running tests in the readme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ sudo: required
 matrix:
   include:
     - rust: 1.34.0
+    # cfg(doctest) is experimental in 1.39 but ignored with 1.34.0, and that snuck in when 1.39.0 wasn't tested
+    - rust: 1.39.0
     - rust: stable
     - rust: beta
     - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ harness = false
 [dev-dependencies]
 criterion = "0.3"
 rand = "0.6.1"
-doc-comment = "0.3"
 
 [features]
 default = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,13 +76,6 @@ extern crate alloc;
 #[cfg(any(feature = "std", test))]
 extern crate std as alloc;
 
-#[cfg(doctest)]
-#[macro_use]
-extern crate doc_comment;
-
-#[cfg(doctest)]
-doctest!("../README.md");
-
 mod chunked_encoder;
 pub mod display;
 #[cfg(any(feature = "std", test))]


### PR DESCRIPTION
It is too much of a pain to support stable (which supports `cfg(doctest)`), 1.39.0 (which has it, but as an experimental feature), and 1.34.0 (which doesn't have it at all).

Fixes #135.