### PR TITLE
Give better error messages when decoding data with trailing newlines

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -216,7 +216,7 @@ fn decode_helper(
             // trailing whitespace is so common that it's worth it to check the last byte to
             // possibly return a better error message
             if let Some(b) = input.last() {
-                if decode_table[*b as usize] == tables::INVALID_VALUE {
+                if *b != b'=' && decode_table[*b as usize] == tables::INVALID_VALUE {
                     return Err(DecodeError::InvalidByte(input.len() - 1, *b));
                 }
             }

--- a/tests/decode.rs
+++ b/tests/decode.rs
@@ -292,7 +292,7 @@ fn decode_reject_invalid_bytes_with_correct_error() {
                     index
                 );
 
-                if length % 4 == 1 {
+                if length % 4 == 1 && !suffix.is_empty() {
                     assert_eq!(DecodeError::InvalidLength, decode(&input).unwrap_err());
                 } else {
                     assert_eq!(


### PR DESCRIPTION
See #105 