### PR TITLE
Make DecoderReader own its inner reader

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1,6 +1,6 @@
-use crate::{Config, PAD_BYTE};
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use crate::{chunked_encoder, STANDARD};
+use crate::{Config, PAD_BYTE};
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use alloc::{string::String, vec};
 use core::convert::TryInto;

--- a/src/write/encoder.rs
+++ b/src/write/encoder.rs
@@ -230,7 +230,9 @@ impl<W: Write> EncoderWriter<W> {
     /// trait. Note that the inner writer might be in an error state or have an incomplete
     /// base64 string written to it.
     pub fn into_inner(mut self) -> W {
-        self.delegate.take().unwrap()
+        self.delegate
+            .take()
+            .expect("Encoder has already had finish() called")
     }
 }
 

--- a/src/write/encoder.rs
+++ b/src/write/encoder.rs
@@ -215,6 +215,23 @@ impl<W: Write> EncoderWriter<W> {
         debug_assert_eq!(0, self.output_occupied_len);
         Ok(())
     }
+
+    /// Unwraps this `EncoderWriter`, returning the base writer it writes base64 encoded output
+    /// to.
+    ///
+    /// Normally this method should not be needed, since `finish()` returns the inner writer if
+    /// it completes successfully. That will also ensure all data has been flushed, which the
+    /// `into_inner()` function does *not* do.
+    ///
+    /// Calling this method after `finish()` has completed successfully will panic, since the
+    /// writer has already been returned.
+    ///
+    /// This method may be useful if the writer implements additional APIs beyond the `Write`
+    /// trait. Note that the inner writer might be in an error state or have an incomplete
+    /// base64 string written to it.
+    pub fn into_inner(mut self) -> W {
+        self.delegate.take().unwrap()
+    }
 }
 
 impl<W: Write> Write for EncoderWriter<W> {


### PR DESCRIPTION
This makes it consistent again with `DecoderWriter`. Closes #151.

Name of the inner reader is changed to be slightly more descriptive.

Also adds an `into_inner` function because I need it for something I'm
working on. This is similar to `std::io::BufReader::into_inner`, which
also has a similar disclaimer.