### PR TITLE
Update MSRV to 1.36.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: required
 
 matrix:
   include:
-    - rust: 1.34.0
+    - rust: 1.36.0
     # cfg(doctest) is experimental in 1.39 but ignored with 1.34.0, and that snuck in when 1.39.0 wasn't tested
     - rust: 1.39.0
     - rust: stable
@@ -34,11 +34,11 @@ env:
   - TERM=dumb
 
 script:
+  - cargo build --all-targets
   - cargo build --verbose $TARGET --no-default-features 
   - cargo build --verbose $TARGET $FEATURES
   - 'if [[ -z "$TARGET" ]]; then cargo test --verbose; fi'
   - 'if [[ -z "$TARGET" ]]; then cargo doc --verbose; fi'
-  - 'if [[ "$TRAVIS_RUST_VERSION" = nightly ]]; then cargo bench --no-run; fi'
   # run for just a second to confirm that it can build and run ok
   - 'if [[ "$TRAVIS_RUST_VERSION" = nightly ]]; then cargo fuzz list | xargs -L 1 -I FUZZER cargo fuzz run FUZZER -- -max_total_time=1; fi'
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ harness = false
 
 [dev-dependencies]
 # 0.3.3 requires rust 1.36.0 for stable copied()
-criterion = "=0.3.2"
+criterion = "0.3.4"
 rand = "0.6.1"
-structopt = "0.3"
+structopt = "0.3.21"
 
 [features]
 default = ["std"]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See the [docs](https://docs.rs/base64) for all the details.
 Rust version compatibility
 ---
 
-The minimum required Rust version is 1.34.0.
+The minimum required Rust version is 1.36.0.
 
 # Contributing
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,7 @@
+# 0.14.0
+
+- MSRV is now 1.36.0
+
 # 0.13.0
 
 - Config methods are const

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1,6 +1,6 @@
-use crate::{Config, PAD_BYTE};
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use crate::{chunked_encoder, STANDARD};
+use crate::{Config, PAD_BYTE};
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use alloc::{string::String, vec};
 use core::convert::TryInto;


### PR DESCRIPTION
Crossbeam (transitive dep) was failing to build on 1.34.0, and this also allows using current criterion.

Also applied rustfmt.