### PR TITLE
Remove outdated comment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ name = "benchmarks"
 harness = false
 
 [dev-dependencies]
-# 0.3.3 requires rust 1.36.0 for stable copied()
 criterion = "0.3.4"
 rand = "0.6.1"
 structopt = "0.3.21"


### PR DESCRIPTION
This comment is no longer relevant as the MSRV was bumped to 1.36.0 and criterion is no longer pinned to 0.3.2.