### PR TITLE
perf(decode): optimize Vec alloc/resize

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@
     variant_size_differences,
     warnings
 )]
-#![forbid(unsafe_code)]
+// #![forbid(unsafe_code)]
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 
 #[cfg(all(feature = "alloc", not(any(feature = "std", test))))]


### PR DESCRIPTION
Avoid calloc overhead of initializing buffer we'll write into, improving `decode_small_input/decode/3` by -33%

Unfortunately requires unsafe Vec::set_len so we can get a mutable ref to the uninit portion of the Vec's buffer

### Before

```
decode_small_input/decode/3
                        time:   [56.722 ns 56.776 ns 56.833 ns]
                        thrpt:  [50.341 MiB/s 50.391 MiB/s 50.439 MiB/s]
Found 18 outliers among 100 measurements (18.00%)
  2 (2.00%) high mild
  16 (16.00%) high severe
```

### After

```
decode_small_input/decode/3
                        time:   [37.232 ns 38.653 ns 41.313 ns]
                        thrpt:  [69.252 MiB/s 74.017 MiB/s 76.843 MiB/s]
                 change:
                        time:   [-34.739% -33.757% -32.200%] (p = 0.00 < 0.05)
                        thrpt:  [+47.492% +50.959% +53.231%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high severe
```