### PR TITLE
decode vec size -- don't oversize the vector

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -95,8 +95,7 @@ pub fn decode_engine<E: Engine, T: AsRef<[u8]>>(
     input: T,
     engine: &E,
 ) -> Result<Vec<u8>, DecodeError> {
-    let mut buffer = Vec::<u8>::with_capacity(input.as_ref().len() * 4 / 3);
-
+    let mut buffer = Vec::<u8>::new();
     decode_engine_vec(input, &mut buffer, engine).map(|_| buffer)
 }
 


### PR DESCRIPTION
Pointed out in #179.

Given that it's about to be resize()'d anyway, probably doesn't serve any purpose to allocate eagerly.