### PR TITLE
API rework

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64"
-version = "0.20.0"
+version = "0.21.0-beta.1"
 authors = ["Alice Maz <alice@alicemaz.com>", "Marshall Pierce <marshall@mpierce.org>"]
 description = "encodes and decodes base64 as bytes or utf8"
 repository = "https://github.com/marshallpierce/rust-base64"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64"
-version = "0.21.0-beta.2"
+version = "0.21.0-rc.1"
 authors = ["Alice Maz <alice@alicemaz.com>", "Marshall Pierce <marshall@mpierce.org>"]
 description = "encodes and decodes base64 as bytes or utf8"
 repository = "https://github.com/marshallpierce/rust-base64"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64"
-version = "0.21.0-beta.1"
+version = "0.21.0-beta.2"
 authors = ["Alice Maz <alice@alicemaz.com>", "Marshall Pierce <marshall@mpierce.org>"]
 description = "encodes and decodes base64 as bytes or utf8"
 repository = "https://github.com/marshallpierce/rust-base64"

--- a/README.md
+++ b/README.md
@@ -14,20 +14,6 @@ e.g. `decode_engine_slice` decodes into an existing `&mut [u8]` and is pretty fa
 whereas `decode_engine` allocates a new `Vec<u8>` and returns it, which might be more convenient in some cases, but is
 slower (although still fast enough for almost any purpose) at 2.1 GiB/s.
 
-## Example
-
-```rust
-use base64::{encode, decode};
-
-fn main() {
-    let a = b"hello world";
-    let b = "aGVsbG8gd29ybGQ=";
-
-    assert_eq!(encode(a), b);
-    assert_eq!(a, &decode(b).unwrap()[..]);
-}
-```
-
 See the [docs](https://docs.rs/base64) for all the details.
 
 ## FAQ

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,49 @@
+# 0.21.0
+
+(not yet released)
+
+
+## Migration
+
+### Functions
+
+| < 0.20 function         | 0.21 equivalent                                                                     |
+|-------------------------|-------------------------------------------------------------------------------------|
+| `encode()`              | `engine::general_purpose::STANDARD.encode()` or `prelude::BASE64_STANDARD.encode()` |
+| `encode_config()`       | `engine.encode()`                                                                   |
+| `encode_config_buf()`   | `engine.encode_string()`                                                            |
+| `encode_config_slice()` | `engine.encode_slice()`                                                             |
+| `decode()`              | `engine::general_purpose::STANDARD.decode()` or `prelude::BASE64_STANDARD.decode()` |
+| `decode_config()`       | `engine.decode()`                                                                   |
+| `decode_config_buf()`   | `engine.decode_vec()`                                                               |
+| `decode_config_slice()` | `engine.decode_slice()`                                                             |
+
+The short-lived 0.20 functions were the 0.13 functions with `config` replaced with `engine`.
+
+### Padding
+
+If applicable, use the preset engines `engine::STANDARD`, `engine::STANDARD_NO_PAD`, `engine::URL_SAFE`,
+or `engine::URL_SAFE_NO_PAD`.
+The `NO_PAD` ones require that padding is absent when decoding, and the others require that
+canonical padding is present .
+
+If you need the < 0.20 behavior that did not care about padding, or want to recreate < 0.20.0's predefined `Config`s
+precisely, see the following table.
+
+| 0.13.1 Config   | 0.20.0+ alphabet | `encode_padding` | `decode_padding_mode` |
+|-----------------|------------------|------------------|-----------------------|
+| STANDARD        | STANDARD         | true             | Indifferent           |
+| STANDARD_NO_PAD | STANDARD         | false            | Indifferent           |
+| URL_SAFE        | URL_SAFE         | true             | Indifferent           |
+| URL_SAFE_NO_PAD | URL_SAFE         | false            | Indifferent           |
+
+
+# 0.21.0-beta.2
+
+## Breaking changes
+
+- Re-exports of preconfigured engines in `engine` are removed in favor of `base64::prelude::...` that are better suited to those who wish to `use` the entire path to a name.
+
 # 0.21.0-beta.1
 
 ## Breaking changes
@@ -20,40 +66,6 @@
 ## Other changes
 
 - `decoded_len_estimate()` is provided to make it easy to size decode buffers correctly.
-
-## Migration
-
-### Functions
-
-| < 0.20 function         | 0.21 equivalent             |
-|-------------------------|-----------------------------|
-| `encode()`              | `engine::STANDARD.encode()` |
-| `encode_config()`       | `engine.encode()`           |
-| `encode_config_buf()`   | `engine.encode_string()`    |
-| `encode_config_slice()` | `engine.encode_slice()`     |
-| `decode()`              | `engine::STANDARD.decode()` |
-| `decode_config()`       | `engine.decode()`           |
-| `decode_config_buf()`   | `engine.decode_vec()`       |
-| `decode_config_slice()` | `engine.decode_slice()`     |
-
-The short-lived 0.20 functions were the 0.13 functions with `config` replaced with `engine`.
-
-### Padding
-
-If applicable, use the preset engines `engine::STANDARD`, `engine::STANDARD_NO_PAD`, `engine::URL_SAFE`,
-or `engine::URL_SAFE_NO_PAD`.
-The `NO_PAD` ones require that padding is absent when decoding, and the others require that
-canonical padding is present .
-
-If you need the < 0.20 behavior that did not care about padding, or want to recreate < 0.20.0's predefined `Config`s
-precisely, see the following table.
-
-| 0.13.1 Config   | 0.20.0+ alphabet | `encode_padding` | `decode_padding_mode` |
-|-----------------|------------------|------------------|-----------------------|
-| STANDARD        | STANDARD         | true             | Indifferent           |
-| STANDARD_NO_PAD | STANDARD         | false            | Indifferent           |
-| URL_SAFE        | URL_SAFE         | true             | Indifferent           |
-| URL_SAFE_NO_PAD | URL_SAFE         | false            | Indifferent           |
 
 # 0.20.0
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -6,6 +6,8 @@
   make its intended usage more
   clear.
 - `GeneralPurpose` and its config are now `pub use`'d in the `engine` module for convenience.
+- Change a few `from()` functions to be `new()`. `from()` causes confusing compiler errors because of confusion with `From::from`, and is a little bit misleading because some of those invocations are not very cheap as one would usually expect from a `from` call.
+
 
 # 0.20.0
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,8 +10,16 @@
   usually expect from a `from` call.
 - `encode*` and `decode*` top level functions are now methods on `Engine`.
 - `DEFAULT_ENGINE` was replaced by `engine::general_purpose::STANDARD`
-- Predefined engine consts `engine::general_purpose::{STANDARD, URL_SAFE, URL_SAFE_NO_PAD}`
+- Predefined engine consts `engine::general_purpose::{STANDARD, STANDARD_NO_PAD, URL_SAFE, URL_SAFE_NO_PAD}`
     - These are `pub use`d into `engine` as well
+- The `*_slice` decode/encode functions now return an error instead of panicking when the output slice is too small
+    - As part of this, there isn't now a public way to decode into a slice _exactly_ the size needed for inputs that
+      aren't multiples of 4 tokens. If adding up to 2 bytes to always be a multiple of 3 bytes for the decode buffer is
+      a problem, file an issue.
+
+## Other changes
+
+- `decoded_len_estimate()` is provided to make it easy to size decode buffers correctly.
 
 ## Migration
 
@@ -32,8 +40,10 @@ The short-lived 0.20 functions were the 0.13 functions with `config` replaced wi
 
 ### Padding
 
-Where possible, use `engine::STANDARD`, `engine::URL_SAFE`, or `engine::URL_SAFE_NO_PAD`. The first two requires that
-canonical padding is present when decoding, and the last requires that padding is absent.
+If applicable, use the preset engines `engine::STANDARD`, `engine::STANDARD_NO_PAD`, `engine::URL_SAFE`,
+or `engine::URL_SAFE_NO_PAD`.
+The `NO_PAD` ones require that padding is absent when decoding, and the others require that
+canonical padding is present .
 
 If you need the < 0.20 behavior that did not care about padding, or want to recreate < 0.20.0's predefined `Config`s
 precisely, see the following table.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,10 +3,9 @@
 ### Breaking changes
 
 - `FastPortable` was only meant to be an interim name, and shouldn't have shipped in 0.20. It is now `GeneralPurpose` to
-  make its intended usage more
-  clear.
+  make its intended usage more clear.
 - `GeneralPurpose` and its config are now `pub use`'d in the `engine` module for convenience.
-- Change a few `from()` functions to be `new()`. `from()` causes confusing compiler errors because of confusion with `From::from`, and is a little bit misleading because some of those invocations are not very cheap as one would usually expect from a `from` call.
+- Change a few `from()` functions to be `new()`. `from()` causes confusing compiler errors because of confusion with `From::from`, and is a little misleading because some of those invocations are not very cheap as one would usually expect from a `from` call.
 - `encode*` and `decode*` top level functions are now methods on `Engine`.
 
 # 0.20.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,22 +1,42 @@
+# 0.20.1
+
+### Breaking changes
+
+- `FastPortable` was only meant to be an interim name, and shouldn't have shipped in 0.20. It is now `GeneralPurpose` to
+  make its intended usage more
+  clear.
+- `GeneralPurpose` and its config are now `pub use`'d in the `engine` module for convenience.
+
 # 0.20.0
 
 ### Breaking changes
 
 - Update MSRV to 1.57.0
-- Decoding can now either ignore padding, require correct padding, or require no padding. The default is to require correct padding.
-  - The `NO_PAD` config now requires that padding be absent when decoding.
+- Decoding can now either ignore padding, require correct padding, or require no padding. The default is to require
+  correct padding.
+    - The `NO_PAD` config now requires that padding be absent when decoding.
 
 ## 0.20.0-alpha.1
 
 ### Breaking changes
-- Extended the `Config` concept into the `Engine` abstraction, allowing the user to pick different encoding / decoding implementations.
-  - What was formerly the only algorithm is now the `FastPortable` engine, so named because it's portable (works on any CPU) and relatively fast.
-  - This opens the door to a portable constant-time implementation ([#153](https://github.com/marshallpierce/rust-base64/pull/153), presumably `ConstantTimePortable`?) for security-sensitive applications that need side-channel resistance, and CPU-specific SIMD implementations for  more speed.
-  - Standard base64 per the RFC is available via `DEFAULT_ENGINE`. To use different alphabets or other settings (padding, etc), create your own engine instance.
-- `CharacterSet` is now `Alphabet` (per the RFC), and allows creating custom alphabets. The corresponding tables that were previously code-generated are now built dynamically.
-- Since there are already multiple breaking changes, various functions are renamed to be more consistent and discoverable.
+
+- Extended the `Config` concept into the `Engine` abstraction, allowing the user to pick different encoding / decoding
+  implementations.
+    - What was formerly the only algorithm is now the `FastPortable` engine, so named because it's portable (works on
+      any CPU) and relatively fast.
+    - This opens the door to a portable constant-time
+      implementation ([#153](https://github.com/marshallpierce/rust-base64/pull/153),
+      presumably `ConstantTimePortable`?) for security-sensitive applications that need side-channel resistance, and
+      CPU-specific SIMD implementations for more speed.
+    - Standard base64 per the RFC is available via `DEFAULT_ENGINE`. To use different alphabets or other settings (
+      padding, etc), create your own engine instance.
+- `CharacterSet` is now `Alphabet` (per the RFC), and allows creating custom alphabets. The corresponding tables that
+  were previously code-generated are now built dynamically.
+- Since there are already multiple breaking changes, various functions are renamed to be more consistent and
+  discoverable.
 - MSRV is now 1.47.0 to allow various things to use `const fn`.
-- `DecoderReader` now owns its inner reader, and can expose it via `into_inner()`. For symmetry, `EncoderWriter` can do the same with its writer.
+- `DecoderReader` now owns its inner reader, and can expose it via `into_inner()`. For symmetry, `EncoderWriter` can do
+  the same with its writer.
 - `encoded_len` is now public so you can size encode buffers precisely.
 
 # 0.13.1
@@ -28,8 +48,11 @@
 - Config methods are const
 - Added `EncoderStringWriter` to allow encoding directly to a String
 - `EncoderWriter` now owns its delegate writer rather than keeping a reference to it (though refs still work)
-    - As a consequence, it is now possible to extract the delegate writer from an `EncoderWriter` via `finish()`, which returns `Result<W>` instead of `Result<()>`. If you were calling `finish()` explicitly, you will now need to use `let _ = foo.finish()` instead of just `foo.finish()` to avoid a warning about the unused value.
-- When decoding input that has both an invalid length and an invalid symbol as the last byte, `InvalidByte` will be emitted instead of `InvalidLength` to make the problem more obvious.
+    - As a consequence, it is now possible to extract the delegate writer from an `EncoderWriter` via `finish()`, which
+      returns `Result<W>` instead of `Result<()>`. If you were calling `finish()` explicitly, you will now need to
+      use `let _ = foo.finish()` instead of just `foo.finish()` to avoid a warning about the unused value.
+- When decoding input that has both an invalid length and an invalid symbol as the last byte, `InvalidByte` will be
+  emitted instead of `InvalidLength` to make the problem more obvious.
 
 # 0.12.2
 
@@ -47,23 +70,31 @@
 - A minor performance improvement in encoding
 
 # 0.11.0
+
 - Minimum rust version 1.34.0
 - `no_std` is now supported via the two new features `alloc` and `std`.
 
 # 0.10.1
 
 - Minimum rust version 1.27.2
-- Fix bug in streaming encoding ([#90](https://github.com/marshallpierce/rust-base64/pull/90)): if the underlying writer didn't write all the bytes given to it, the remaining bytes would not be retried later. See the docs on `EncoderWriter::write`.
+- Fix bug in streaming encoding ([#90](https://github.com/marshallpierce/rust-base64/pull/90)): if the underlying writer
+  didn't write all the bytes given to it, the remaining bytes would not be retried later. See the docs
+  on `EncoderWriter::write`.
 - Make it configurable whether or not to return an error when decoding detects excess trailing bits.
 
 # 0.10.0
 
-- Remove line wrapping. Line wrapping was never a great conceptual fit in this library, and other features (streaming encoding, etc) either couldn't support it or could support only special cases of it with a great increase in complexity. Line wrapping has been pulled out into a [line-wrap](https://crates.io/crates/line-wrap) crate, so it's still available if you need it.
-  - `Base64Display` creation no longer uses a `Result` because it can't fail, which means its helper methods for common
-  configs that `unwrap()` for you are no longer needed
+- Remove line wrapping. Line wrapping was never a great conceptual fit in this library, and other features (streaming
+  encoding, etc) either couldn't support it or could support only special cases of it with a great increase in
+  complexity. Line wrapping has been pulled out into a [line-wrap](https://crates.io/crates/line-wrap) crate, so it's
+  still available if you need it.
+    - `Base64Display` creation no longer uses a `Result` because it can't fail, which means its helper methods for
+      common
+      configs that `unwrap()` for you are no longer needed
 - Add a streaming encoder `Write` impl to transparently base64 as you write.
 - Remove the remaining `unsafe` code.
-- Remove whitespace stripping to simplify `no_std` support. No out of the box configs use it, and it's trivial to do yourself if needed: `filter(|b| !b" \n\t\r\x0b\x0c".contains(b)`.
+- Remove whitespace stripping to simplify `no_std` support. No out of the box configs use it, and it's trivial to do
+  yourself if needed: `filter(|b| !b" \n\t\r\x0b\x0c".contains(b)`.
 - Detect invalid trailing symbols when decoding and return an error rather than silently ignoring them.
 
 # 0.9.3

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -37,6 +37,9 @@ precisely, see the following table.
 | URL_SAFE        | URL_SAFE         | true             | Indifferent           |
 | URL_SAFE_NO_PAD | URL_SAFE         | false            | Indifferent           |
 
+# 0.21.0-rc.1
+
+- Restore the ability to decode into a slice of precisely the correct length with `Engine.decode_slice_unchecked`.
 
 # 0.21.0-beta.2
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -7,6 +7,9 @@
 - `GeneralPurpose` and its config are now `pub use`'d in the `engine` module for convenience.
 - Change a few `from()` functions to be `new()`. `from()` causes confusing compiler errors because of confusion with `From::from`, and is a little misleading because some of those invocations are not very cheap as one would usually expect from a `from` call.
 - `encode*` and `decode*` top level functions are now methods on `Engine`.
+- `DEFAULT_ENGINE` was replaced by `engine::general_purpose::STANDARD`
+- Predefined engine consts `engine::general_purpose::{STANDARD, URL_SAFE, URL_SAFE_NO_PAD}`
+  - These are `pub use`d into `engine` as well
 
 # 0.20.0
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -7,7 +7,7 @@
   clear.
 - `GeneralPurpose` and its config are now `pub use`'d in the `engine` module for convenience.
 - Change a few `from()` functions to be `new()`. `from()` causes confusing compiler errors because of confusion with `From::from`, and is a little bit misleading because some of those invocations are not very cheap as one would usually expect from a `from` call.
-
+- `encode*` and `decode*` top level functions are now methods on `Engine`.
 
 # 0.20.0
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,4 @@
-# 0.20.1
+# 0.21.0-beta.1
 
 ## Breaking changes
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,19 +1,53 @@
 # 0.20.1
 
-### Breaking changes
+## Breaking changes
 
 - `FastPortable` was only meant to be an interim name, and shouldn't have shipped in 0.20. It is now `GeneralPurpose` to
   make its intended usage more clear.
 - `GeneralPurpose` and its config are now `pub use`'d in the `engine` module for convenience.
-- Change a few `from()` functions to be `new()`. `from()` causes confusing compiler errors because of confusion with `From::from`, and is a little misleading because some of those invocations are not very cheap as one would usually expect from a `from` call.
+- Change a few `from()` functions to be `new()`. `from()` causes confusing compiler errors because of confusion
+  with `From::from`, and is a little misleading because some of those invocations are not very cheap as one would
+  usually expect from a `from` call.
 - `encode*` and `decode*` top level functions are now methods on `Engine`.
 - `DEFAULT_ENGINE` was replaced by `engine::general_purpose::STANDARD`
 - Predefined engine consts `engine::general_purpose::{STANDARD, URL_SAFE, URL_SAFE_NO_PAD}`
-  - These are `pub use`d into `engine` as well
+    - These are `pub use`d into `engine` as well
+
+## Migration
+
+### Functions
+
+| < 0.20 function         | 0.21 equivalent             |
+|-------------------------|-----------------------------|
+| `encode()`              | `engine::STANDARD.encode()` |
+| `encode_config()`       | `engine.encode()`           |
+| `encode_config_buf()`   | `engine.encode_string()`    |
+| `encode_config_slice()` | `engine.encode_slice()`     |
+| `decode()`              | `engine::STANDARD.decode()` |
+| `decode_config()`       | `engine.decode()`           |
+| `decode_config_buf()`   | `engine.decode_vec()`       |
+| `decode_config_slice()` | `engine.decode_slice()`     |
+
+The short-lived 0.20 functions were the 0.13 functions with `config` replaced with `engine`.
+
+### Padding
+
+Where possible, use `engine::STANDARD`, `engine::URL_SAFE`, or `engine::URL_SAFE_NO_PAD`. The first two requires that
+canonical padding is present when decoding, and the last requires that padding is absent.
+
+If you need the < 0.20 behavior that did not care about padding, or want to recreate < 0.20.0's predefined `Config`s
+precisely, see the following table.
+
+| 0.13.1 Config   | 0.20.0+ alphabet | `encode_padding` | `decode_padding_mode` |
+|-----------------|------------------|------------------|-----------------------|
+| STANDARD        | STANDARD         | true             | Indifferent           |
+| STANDARD_NO_PAD | STANDARD         | false            | Indifferent           |
+| URL_SAFE        | URL_SAFE         | true             | Indifferent           |
+| URL_SAFE_NO_PAD | URL_SAFE         | false            | Indifferent           |
 
 # 0.20.0
 
-### Breaking changes
+## Breaking changes
 
 - Update MSRV to 1.57.0
 - Decoding can now either ignore padding, require correct padding, or require no padding. The default is to require

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -40,6 +40,7 @@ precisely, see the following table.
 # 0.21.0-rc.1
 
 - Restore the ability to decode into a slice of precisely the correct length with `Engine.decode_slice_unchecked`.
+- Add `Engine` as a `pub use` in `prelude`.
 
 # 0.21.0-beta.2
 

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -3,7 +3,7 @@ extern crate criterion;
 
 use base64::{
     display,
-    engine::{Engine, DEFAULT_ENGINE},
+    engine::{Engine, STANDARD},
     write,
 };
 use criterion::{black_box, Bencher, BenchmarkId, Criterion, Throughput};
@@ -13,10 +13,10 @@ use std::io::{self, Read, Write};
 fn do_decode_bench(b: &mut Bencher, &size: &usize) {
     let mut v: Vec<u8> = Vec::with_capacity(size * 3 / 4);
     fill(&mut v);
-    let encoded = DEFAULT_ENGINE.encode(&v);
+    let encoded = STANDARD.encode(&v);
 
     b.iter(|| {
-        let orig = DEFAULT_ENGINE.decode(&encoded);
+        let orig = STANDARD.decode(&encoded);
         black_box(&orig);
     });
 }
@@ -24,11 +24,11 @@ fn do_decode_bench(b: &mut Bencher, &size: &usize) {
 fn do_decode_bench_reuse_buf(b: &mut Bencher, &size: &usize) {
     let mut v: Vec<u8> = Vec::with_capacity(size * 3 / 4);
     fill(&mut v);
-    let encoded = DEFAULT_ENGINE.encode(&v);
+    let encoded = STANDARD.encode(&v);
 
     let mut buf = Vec::new();
     b.iter(|| {
-        DEFAULT_ENGINE.decode_vec(&encoded, &mut buf).unwrap();
+        STANDARD.decode_vec(&encoded, &mut buf).unwrap();
         black_box(&buf);
         buf.clear();
     });
@@ -37,12 +37,12 @@ fn do_decode_bench_reuse_buf(b: &mut Bencher, &size: &usize) {
 fn do_decode_bench_slice(b: &mut Bencher, &size: &usize) {
     let mut v: Vec<u8> = Vec::with_capacity(size * 3 / 4);
     fill(&mut v);
-    let encoded = DEFAULT_ENGINE.encode(&v);
+    let encoded = STANDARD.encode(&v);
 
     let mut buf = Vec::new();
     buf.resize(size, 0);
     b.iter(|| {
-        DEFAULT_ENGINE.decode_slice(&encoded, &mut buf).unwrap();
+        STANDARD.decode_slice(&encoded, &mut buf).unwrap();
         black_box(&buf);
     });
 }
@@ -50,7 +50,7 @@ fn do_decode_bench_slice(b: &mut Bencher, &size: &usize) {
 fn do_decode_bench_stream(b: &mut Bencher, &size: &usize) {
     let mut v: Vec<u8> = Vec::with_capacity(size * 3 / 4);
     fill(&mut v);
-    let encoded = DEFAULT_ENGINE.encode(&v);
+    let encoded = STANDARD.encode(&v);
 
     let mut buf = Vec::new();
     buf.resize(size, 0);
@@ -58,7 +58,7 @@ fn do_decode_bench_stream(b: &mut Bencher, &size: &usize) {
 
     b.iter(|| {
         let mut cursor = io::Cursor::new(&encoded[..]);
-        let mut decoder = base64::read::DecoderReader::new(&mut cursor, &DEFAULT_ENGINE);
+        let mut decoder = base64::read::DecoderReader::new(&mut cursor, &STANDARD);
         decoder.read_to_end(&mut buf).unwrap();
         buf.clear();
         black_box(&buf);
@@ -69,7 +69,7 @@ fn do_encode_bench(b: &mut Bencher, &size: &usize) {
     let mut v: Vec<u8> = Vec::with_capacity(size);
     fill(&mut v);
     b.iter(|| {
-        let e = DEFAULT_ENGINE.encode(&v);
+        let e = STANDARD.encode(&v);
         black_box(&e);
     });
 }
@@ -78,7 +78,7 @@ fn do_encode_bench_display(b: &mut Bencher, &size: &usize) {
     let mut v: Vec<u8> = Vec::with_capacity(size);
     fill(&mut v);
     b.iter(|| {
-        let e = format!("{}", display::Base64Display::new(&v, &DEFAULT_ENGINE));
+        let e = format!("{}", display::Base64Display::new(&v, &STANDARD));
         black_box(&e);
     });
 }
@@ -88,7 +88,7 @@ fn do_encode_bench_reuse_buf(b: &mut Bencher, &size: &usize) {
     fill(&mut v);
     let mut buf = String::new();
     b.iter(|| {
-        DEFAULT_ENGINE.encode_string(&v, &mut buf);
+        STANDARD.encode_string(&v, &mut buf);
         buf.clear();
     });
 }
@@ -100,7 +100,7 @@ fn do_encode_bench_slice(b: &mut Bencher, &size: &usize) {
     // conservative estimate of encoded size
     buf.resize(v.len() * 2, 0);
     b.iter(|| {
-        DEFAULT_ENGINE.encode_slice(&v, &mut buf);
+        STANDARD.encode_slice(&v, &mut buf);
     });
 }
 
@@ -112,7 +112,7 @@ fn do_encode_bench_stream(b: &mut Bencher, &size: &usize) {
     buf.reserve(size * 2);
     b.iter(|| {
         buf.clear();
-        let mut stream_enc = write::EncoderWriter::new(&mut buf, &DEFAULT_ENGINE);
+        let mut stream_enc = write::EncoderWriter::new(&mut buf, &STANDARD);
         stream_enc.write_all(&v).unwrap();
         stream_enc.flush().unwrap();
     });
@@ -123,7 +123,7 @@ fn do_encode_bench_string_stream(b: &mut Bencher, &size: &usize) {
     fill(&mut v);
 
     b.iter(|| {
-        let mut stream_enc = write::EncoderStringWriter::new(&DEFAULT_ENGINE);
+        let mut stream_enc = write::EncoderStringWriter::new(&STANDARD);
         stream_enc.write_all(&v).unwrap();
         stream_enc.flush().unwrap();
         let _ = stream_enc.into_inner();
@@ -137,7 +137,7 @@ fn do_encode_bench_string_reuse_buf_stream(b: &mut Bencher, &size: &usize) {
     let mut buf = String::new();
     b.iter(|| {
         buf.clear();
-        let mut stream_enc = write::EncoderStringWriter::from_consumer(&mut buf, &DEFAULT_ENGINE);
+        let mut stream_enc = write::EncoderStringWriter::from_consumer(&mut buf, &STANDARD);
         stream_enc.write_all(&v).unwrap();
         stream_enc.flush().unwrap();
         let _ = stream_enc.into_inner();

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -60,7 +60,7 @@ fn do_decode_bench_stream(b: &mut Bencher, &size: &usize) {
 
     b.iter(|| {
         let mut cursor = io::Cursor::new(&encoded[..]);
-        let mut decoder = base64::read::DecoderReader::from(&mut cursor, &DEFAULT_ENGINE);
+        let mut decoder = base64::read::DecoderReader::new(&mut cursor, &DEFAULT_ENGINE);
         decoder.read_to_end(&mut buf).unwrap();
         buf.clear();
         black_box(&buf);
@@ -80,7 +80,7 @@ fn do_encode_bench_display(b: &mut Bencher, &size: &usize) {
     let mut v: Vec<u8> = Vec::with_capacity(size);
     fill(&mut v);
     b.iter(|| {
-        let e = format!("{}", display::Base64Display::from(&v, &DEFAULT_ENGINE));
+        let e = format!("{}", display::Base64Display::new(&v, &DEFAULT_ENGINE));
         black_box(&e);
     });
 }
@@ -114,7 +114,7 @@ fn do_encode_bench_stream(b: &mut Bencher, &size: &usize) {
     buf.reserve(size * 2);
     b.iter(|| {
         buf.clear();
-        let mut stream_enc = write::EncoderWriter::from(&mut buf, &DEFAULT_ENGINE);
+        let mut stream_enc = write::EncoderWriter::new(&mut buf, &DEFAULT_ENGINE);
         stream_enc.write_all(&v).unwrap();
         stream_enc.flush().unwrap();
     });
@@ -125,7 +125,7 @@ fn do_encode_bench_string_stream(b: &mut Bencher, &size: &usize) {
     fill(&mut v);
 
     b.iter(|| {
-        let mut stream_enc = write::EncoderStringWriter::from(&DEFAULT_ENGINE);
+        let mut stream_enc = write::EncoderStringWriter::new(&DEFAULT_ENGINE);
         stream_enc.write_all(&v).unwrap();
         stream_enc.flush().unwrap();
         let _ = stream_enc.into_inner();

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -2,7 +2,7 @@
 extern crate criterion;
 
 use base64::{
-    decode, decode_engine_slice, decode_engine_vec, display,
+    display,
     engine::{Engine, DEFAULT_ENGINE},
     write,
 };
@@ -16,7 +16,7 @@ fn do_decode_bench(b: &mut Bencher, &size: &usize) {
     let encoded = DEFAULT_ENGINE.encode(&v);
 
     b.iter(|| {
-        let orig = decode(&encoded);
+        let orig = DEFAULT_ENGINE.decode(&encoded);
         black_box(&orig);
     });
 }
@@ -28,7 +28,7 @@ fn do_decode_bench_reuse_buf(b: &mut Bencher, &size: &usize) {
 
     let mut buf = Vec::new();
     b.iter(|| {
-        decode_engine_vec(&encoded, &mut buf, &DEFAULT_ENGINE).unwrap();
+        DEFAULT_ENGINE.decode_vec(&encoded, &mut buf).unwrap();
         black_box(&buf);
         buf.clear();
     });
@@ -42,7 +42,7 @@ fn do_decode_bench_slice(b: &mut Bencher, &size: &usize) {
     let mut buf = Vec::new();
     buf.resize(size, 0);
     b.iter(|| {
-        decode_engine_slice(&encoded, &mut buf, &DEFAULT_ENGINE).unwrap();
+        DEFAULT_ENGINE.decode_slice(&encoded, &mut buf).unwrap();
         black_box(&buf);
     });
 }

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -99,9 +99,7 @@ fn do_encode_bench_slice(b: &mut Bencher, &size: &usize) {
     let mut buf = Vec::new();
     // conservative estimate of encoded size
     buf.resize(v.len() * 2, 0);
-    b.iter(|| {
-        STANDARD.encode_slice(&v, &mut buf);
-    });
+    b.iter(|| STANDARD.encode_slice(&v, &mut buf).unwrap());
 }
 
 fn do_encode_bench_stream(b: &mut Bencher, &size: &usize) {

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -3,7 +3,7 @@ extern crate criterion;
 
 use base64::{
     display,
-    engine::{Engine, STANDARD},
+    engine::{general_purpose::STANDARD, Engine},
     write,
 };
 use criterion::{black_box, Bencher, BenchmarkId, Criterion, Throughput};

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,13 +1,11 @@
 #[macro_use]
 extern crate criterion;
 
-use base64::display;
 use base64::{
-    decode, decode_engine_slice, decode_engine_vec, encode, encode_engine_slice,
-    encode_engine_string, write,
+    decode, decode_engine_slice, decode_engine_vec, display,
+    engine::{Engine, DEFAULT_ENGINE},
+    write,
 };
-
-use base64::engine::DEFAULT_ENGINE;
 use criterion::{black_box, Bencher, BenchmarkId, Criterion, Throughput};
 use rand::{Rng, SeedableRng};
 use std::io::{self, Read, Write};
@@ -15,7 +13,7 @@ use std::io::{self, Read, Write};
 fn do_decode_bench(b: &mut Bencher, &size: &usize) {
     let mut v: Vec<u8> = Vec::with_capacity(size * 3 / 4);
     fill(&mut v);
-    let encoded = encode(&v);
+    let encoded = DEFAULT_ENGINE.encode(&v);
 
     b.iter(|| {
         let orig = decode(&encoded);
@@ -26,7 +24,7 @@ fn do_decode_bench(b: &mut Bencher, &size: &usize) {
 fn do_decode_bench_reuse_buf(b: &mut Bencher, &size: &usize) {
     let mut v: Vec<u8> = Vec::with_capacity(size * 3 / 4);
     fill(&mut v);
-    let encoded = encode(&v);
+    let encoded = DEFAULT_ENGINE.encode(&v);
 
     let mut buf = Vec::new();
     b.iter(|| {
@@ -39,7 +37,7 @@ fn do_decode_bench_reuse_buf(b: &mut Bencher, &size: &usize) {
 fn do_decode_bench_slice(b: &mut Bencher, &size: &usize) {
     let mut v: Vec<u8> = Vec::with_capacity(size * 3 / 4);
     fill(&mut v);
-    let encoded = encode(&v);
+    let encoded = DEFAULT_ENGINE.encode(&v);
 
     let mut buf = Vec::new();
     buf.resize(size, 0);
@@ -52,7 +50,7 @@ fn do_decode_bench_slice(b: &mut Bencher, &size: &usize) {
 fn do_decode_bench_stream(b: &mut Bencher, &size: &usize) {
     let mut v: Vec<u8> = Vec::with_capacity(size * 3 / 4);
     fill(&mut v);
-    let encoded = encode(&v);
+    let encoded = DEFAULT_ENGINE.encode(&v);
 
     let mut buf = Vec::new();
     buf.resize(size, 0);
@@ -71,7 +69,7 @@ fn do_encode_bench(b: &mut Bencher, &size: &usize) {
     let mut v: Vec<u8> = Vec::with_capacity(size);
     fill(&mut v);
     b.iter(|| {
-        let e = encode(&v);
+        let e = DEFAULT_ENGINE.encode(&v);
         black_box(&e);
     });
 }
@@ -90,7 +88,7 @@ fn do_encode_bench_reuse_buf(b: &mut Bencher, &size: &usize) {
     fill(&mut v);
     let mut buf = String::new();
     b.iter(|| {
-        encode_engine_string(&v, &mut buf, &DEFAULT_ENGINE);
+        DEFAULT_ENGINE.encode_string(&v, &mut buf);
         buf.clear();
     });
 }
@@ -102,7 +100,7 @@ fn do_encode_bench_slice(b: &mut Bencher, &size: &usize) {
     // conservative estimate of encoded size
     buf.resize(v.len() * 2, 0);
     b.iter(|| {
-        encode_engine_slice(&v, &mut buf, &DEFAULT_ENGINE);
+        DEFAULT_ENGINE.encode_slice(&v, &mut buf);
     });
 }
 

--- a/examples/base64.rs
+++ b/examples/base64.rs
@@ -61,12 +61,12 @@ fn main() {
     };
 
     let alphabet = opt.alphabet.unwrap_or_default();
-    let engine = engine::fast_portable::FastPortable::from(
+    let engine = engine::GeneralPurpose::from(
         &match alphabet {
             Alphabet::Standard => alphabet::STANDARD,
             Alphabet::UrlSafe => alphabet::URL_SAFE,
         },
-        engine::fast_portable::PAD,
+        engine::general_purpose::PAD,
     );
 
     let stdout = io::stdout();

--- a/examples/base64.rs
+++ b/examples/base64.rs
@@ -61,7 +61,7 @@ fn main() {
     };
 
     let alphabet = opt.alphabet.unwrap_or_default();
-    let engine = engine::GeneralPurpose::from(
+    let engine = engine::GeneralPurpose::new(
         &match alphabet {
             Alphabet::Standard => alphabet::STANDARD,
             Alphabet::UrlSafe => alphabet::URL_SAFE,
@@ -72,10 +72,10 @@ fn main() {
     let stdout = io::stdout();
     let mut stdout = stdout.lock();
     let r = if opt.decode {
-        let mut decoder = read::DecoderReader::from(&mut input, &engine);
+        let mut decoder = read::DecoderReader::new(&mut input, &engine);
         io::copy(&mut decoder, &mut stdout)
     } else {
-        let mut encoder = write::EncoderWriter::from(&mut stdout, &engine);
+        let mut encoder = write::EncoderWriter::new(&mut stdout, &engine);
         io::copy(&mut input, &mut encoder)
     };
     if let Err(e) = r {

--- a/fuzz/fuzzers/decode_random.rs
+++ b/fuzz/fuzzers/decode_random.rs
@@ -11,5 +11,5 @@ fuzz_target!(|data: &[u8]| {
 
     // The data probably isn't valid base64 input, but as long as it returns an error instead
     // of crashing, that's correct behavior.
-    let _ = decode_engine(data, &engine);
+    let _ = engine.decode(data);
 });

--- a/fuzz/fuzzers/roundtrip.rs
+++ b/fuzz/fuzzers/roundtrip.rs
@@ -2,7 +2,7 @@
 #[macro_use] extern crate libfuzzer_sys;
 extern crate base64;
 
-use base64::{Engine as _, engine::STANDARD};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
 
 fuzz_target!(|data: &[u8]| {
     let encoded = STANDARD.encode(data);

--- a/fuzz/fuzzers/roundtrip.rs
+++ b/fuzz/fuzzers/roundtrip.rs
@@ -6,6 +6,6 @@ use base64::{Engine as _, engine::DEFAULT_ENGINE};
 
 fuzz_target!(|data: &[u8]| {
     let encoded = DEFAULT_ENGINE.encode(data);
-    let decoded = base64::decode_engine(&encoded, &DEFAULT_ENGINE).unwrap();
+    let decoded = DEFAULT_ENGINE.decode(&encoded).unwrap();
     assert_eq!(data, decoded.as_slice());
 });

--- a/fuzz/fuzzers/roundtrip.rs
+++ b/fuzz/fuzzers/roundtrip.rs
@@ -2,10 +2,10 @@
 #[macro_use] extern crate libfuzzer_sys;
 extern crate base64;
 
-use base64::{Engine as _, engine::DEFAULT_ENGINE};
+use base64::{Engine as _, engine::STANDARD};
 
 fuzz_target!(|data: &[u8]| {
-    let encoded = DEFAULT_ENGINE.encode(data);
-    let decoded = DEFAULT_ENGINE.decode(&encoded).unwrap();
+    let encoded = STANDARD.encode(data);
+    let decoded = STANDARD.decode(&encoded).unwrap();
     assert_eq!(data, decoded.as_slice());
 });

--- a/fuzz/fuzzers/roundtrip.rs
+++ b/fuzz/fuzzers/roundtrip.rs
@@ -2,10 +2,10 @@
 #[macro_use] extern crate libfuzzer_sys;
 extern crate base64;
 
-use base64::engine::DEFAULT_ENGINE;
+use base64::{Engine as _, engine::DEFAULT_ENGINE};
 
 fuzz_target!(|data: &[u8]| {
-    let encoded = base64::encode_engine(data, &DEFAULT_ENGINE);
+    let encoded = DEFAULT_ENGINE.encode(data);
     let decoded = base64::decode_engine(&encoded, &DEFAULT_ENGINE).unwrap();
     assert_eq!(data, decoded.as_slice());
 });

--- a/fuzz/fuzzers/roundtrip_no_pad.rs
+++ b/fuzz/fuzzers/roundtrip_no_pad.rs
@@ -12,6 +12,6 @@ fuzz_target!(|data: &[u8]| {
     let engine = general_purpose::GeneralPurpose::new(&base64::alphabet::STANDARD, config);
 
     let encoded = engine.encode(data);
-    let decoded = base64::decode_engine(&encoded, &engine).unwrap();
+    let decoded = engine.decode(&encoded).unwrap();
     assert_eq!(data, decoded.as_slice());
 });

--- a/fuzz/fuzzers/roundtrip_no_pad.rs
+++ b/fuzz/fuzzers/roundtrip_no_pad.rs
@@ -3,15 +3,15 @@
 extern crate libfuzzer_sys;
 extern crate base64;
 
-use base64::engine::{self, general_purpose};
+use base64::{Engine as _, engine::{self, general_purpose}};
 
 fuzz_target!(|data: &[u8]| {
     let config = general_purpose::GeneralPurposeConfig::new()
         .with_encode_padding(false)
         .with_decode_padding_mode(engine::DecodePaddingMode::RequireNone);
-    let engine = general_purpose::GeneralPurpose::from(&base64::alphabet::STANDARD, config);
+    let engine = general_purpose::GeneralPurpose::new(&base64::alphabet::STANDARD, config);
 
-    let encoded = base64::encode_engine(data, &engine);
+    let encoded = engine.encode(data);
     let decoded = base64::decode_engine(&encoded, &engine).unwrap();
     assert_eq!(data, decoded.as_slice());
 });

--- a/fuzz/fuzzers/roundtrip_no_pad.rs
+++ b/fuzz/fuzzers/roundtrip_no_pad.rs
@@ -3,13 +3,13 @@
 extern crate libfuzzer_sys;
 extern crate base64;
 
-use base64::engine::{self, fast_portable};
+use base64::engine::{self, general_purpose};
 
 fuzz_target!(|data: &[u8]| {
-    let config = fast_portable::FastPortableConfig::new()
+    let config = general_purpose::GeneralPurposeConfig::new()
         .with_encode_padding(false)
         .with_decode_padding_mode(engine::DecodePaddingMode::RequireNone);
-    let engine = fast_portable::FastPortable::from(&base64::alphabet::STANDARD, config);
+    let engine = general_purpose::GeneralPurpose::from(&base64::alphabet::STANDARD, config);
 
     let encoded = base64::encode_engine(data, &engine);
     let decoded = base64::decode_engine(&encoded, &engine).unwrap();

--- a/fuzz/fuzzers/roundtrip_random_config.rs
+++ b/fuzz/fuzzers/roundtrip_random_config.rs
@@ -9,7 +9,7 @@ mod utils;
 fuzz_target!(|data: &[u8]| {
     let engine = utils::random_engine(data);
 
-    let encoded = encode_engine(data, &engine);
+    let encoded = engine.encode(data);
     let decoded = decode_engine(&encoded, &engine).unwrap();
     assert_eq!(data, decoded.as_slice());
 });

--- a/fuzz/fuzzers/roundtrip_random_config.rs
+++ b/fuzz/fuzzers/roundtrip_random_config.rs
@@ -10,6 +10,6 @@ fuzz_target!(|data: &[u8]| {
     let engine = utils::random_engine(data);
 
     let encoded = engine.encode(data);
-    let decoded = decode_engine(&encoded, &engine).unwrap();
+    let decoded = engine.decode(&encoded).unwrap();
     assert_eq!(data, decoded.as_slice());
 });

--- a/fuzz/fuzzers/utils.rs
+++ b/fuzz/fuzzers/utils.rs
@@ -2,12 +2,12 @@ extern crate rand;
 extern crate rand_pcg;
 extern crate sha2;
 
-use base64::{alphabet, engine::{self, fast_portable}};
+use base64::{alphabet, engine::{self, general_purpose}};
 use self::rand::{Rng, SeedableRng};
 use self::rand_pcg::Pcg32;
 use self::sha2::Digest as _;
 
-pub fn random_engine(data: &[u8]) -> fast_portable::FastPortable {
+pub fn random_engine(data: &[u8]) -> general_purpose::GeneralPurpose {
     // use sha256 of data as rng seed so it's repeatable
     let mut hasher = sha2::Sha256::new();
     hasher.update(data);
@@ -30,10 +30,10 @@ pub fn random_engine(data: &[u8]) -> fast_portable::FastPortable {
     } else {
         engine::DecodePaddingMode::RequireNone
     };
-    let config = fast_portable::FastPortableConfig::new()
+    let config = general_purpose::GeneralPurposeConfig::new()
         .with_encode_padding(encode_padding)
         .with_decode_allow_trailing_bits(rng.gen())
         .with_decode_padding_mode(decode_padding);
 
-    fast_portable::FastPortable::from(&alphabet, config)
+    general_purpose::GeneralPurpose::from(&alphabet, config)
 }

--- a/fuzz/fuzzers/utils.rs
+++ b/fuzz/fuzzers/utils.rs
@@ -35,5 +35,5 @@ pub fn random_engine(data: &[u8]) -> general_purpose::GeneralPurpose {
         .with_decode_allow_trailing_bits(rng.gen())
         .with_decode_padding_mode(decode_padding);
 
-    general_purpose::GeneralPurpose::from(&alphabet, config)
+    general_purpose::GeneralPurpose::new(&alphabet, config)
 }

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -1,7 +1,7 @@
 //! Provides [Alphabet] and constants for alphabets commonly used in the wild.
 
 use crate::PAD_BYTE;
-use core::{convert, fmt};
+use core::fmt;
 #[cfg(any(feature = "std", test))]
 use std::error;
 
@@ -93,7 +93,7 @@ impl Alphabet {
     }
 }
 
-impl convert::TryFrom<&str> for Alphabet {
+impl TryFrom<&str> for Alphabet {
     type Error = ParseAlphabetError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -15,9 +15,9 @@ const ALPHABET_SIZE: usize = 64;
 /// ```
 /// let custom = base64::alphabet::Alphabet::from_str("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/").unwrap();
 ///
-/// let engine = base64::engine::fast_portable::FastPortable::from(
+/// let engine = base64::engine::GeneralPurpose::from(
 ///     &custom,
-///     base64::engine::fast_portable::PAD);
+///     base64::engine::general_purpose::PAD);
 /// ```
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Alphabet {

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -13,9 +13,9 @@ const ALPHABET_SIZE: usize = 64;
 /// can be made via `from_str` or the `TryFrom<str>` implementation.
 ///
 /// ```
-/// let custom = base64::alphabet::Alphabet::from_str("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/").unwrap();
+/// let custom = base64::alphabet::Alphabet::new("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/").unwrap();
 ///
-/// let engine = base64::engine::GeneralPurpose::from(
+/// let engine = base64::engine::GeneralPurpose::new(
 ///     &custom,
 ///     base64::engine::general_purpose::PAD);
 /// ```
@@ -44,7 +44,7 @@ impl Alphabet {
     /// Create an `Alphabet` from a string of 64 unique printable ASCII bytes.
     ///
     /// The `=` byte is not allowed as it is used for padding.
-    pub const fn from_str(alphabet: &str) -> Result<Self, ParseAlphabetError> {
+    pub const fn new(alphabet: &str) -> Result<Self, ParseAlphabetError> {
         let bytes = alphabet.as_bytes();
         if bytes.len() != ALPHABET_SIZE {
             return Err(ParseAlphabetError::InvalidLength);
@@ -97,7 +97,7 @@ impl TryFrom<&str> for Alphabet {
     type Error = ParseAlphabetError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        Self::from_str(value)
+        Self::new(value)
     }
 }
 
@@ -177,7 +177,7 @@ mod tests {
     fn detects_duplicate_start() {
         assert_eq!(
             ParseAlphabetError::DuplicatedByte(b'A'),
-            Alphabet::from_str("AACDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/")
+            Alphabet::new("AACDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/")
                 .unwrap_err()
         );
     }
@@ -186,7 +186,7 @@ mod tests {
     fn detects_duplicate_end() {
         assert_eq!(
             ParseAlphabetError::DuplicatedByte(b'/'),
-            Alphabet::from_str("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789//")
+            Alphabet::new("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789//")
                 .unwrap_err()
         );
     }
@@ -195,7 +195,7 @@ mod tests {
     fn detects_duplicate_middle() {
         assert_eq!(
             ParseAlphabetError::DuplicatedByte(b'Z'),
-            Alphabet::from_str("ABCDEFGHIJKLMNOPQRSTUVWXYZZbcdefghijklmnopqrstuvwxyz0123456789+/")
+            Alphabet::new("ABCDEFGHIJKLMNOPQRSTUVWXYZZbcdefghijklmnopqrstuvwxyz0123456789+/")
                 .unwrap_err()
         );
     }
@@ -204,7 +204,7 @@ mod tests {
     fn detects_length() {
         assert_eq!(
             ParseAlphabetError::InvalidLength,
-            Alphabet::from_str(
+            Alphabet::new(
                 "xxxxxxxxxABCDEFGHIJKLMNOPQRSTUVWXYZZbcdefghijklmnopqrstuvwxyz0123456789+/",
             )
             .unwrap_err()
@@ -215,7 +215,7 @@ mod tests {
     fn detects_padding() {
         assert_eq!(
             ParseAlphabetError::ReservedByte(b'='),
-            Alphabet::from_str("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+=")
+            Alphabet::new("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+=")
                 .unwrap_err()
         );
     }
@@ -225,10 +225,8 @@ mod tests {
         // form feed
         assert_eq!(
             ParseAlphabetError::UnprintableByte(0xc),
-            Alphabet::from_str(
-                "\x0cBCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
-            )
-            .unwrap_err()
+            Alphabet::new("\x0cBCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/")
+                .unwrap_err()
         );
     }
 

--- a/src/chunked_encoder.rs
+++ b/src/chunked_encoder.rs
@@ -24,7 +24,7 @@ pub struct ChunkedEncoder<'e, E: Engine> {
 }
 
 impl<'e, E: Engine> ChunkedEncoder<'e, E> {
-    pub fn from(engine: &'e E) -> ChunkedEncoder<'e, E> {
+    pub fn new(engine: &'e E) -> ChunkedEncoder<'e, E> {
         ChunkedEncoder {
             engine,
             max_input_chunk_len: max_input_length(BUF_SIZE, engine.config().encode_padding()),
@@ -88,7 +88,7 @@ pub(crate) struct StringSink<'a> {
 
 #[cfg(any(feature = "alloc", feature = "std", test))]
 impl<'a> StringSink<'a> {
-    pub(crate) fn from(s: &mut String) -> StringSink {
+    pub(crate) fn new(s: &mut String) -> StringSink {
         StringSink { string: s }
     }
 }
@@ -202,9 +202,9 @@ pub mod tests {
     fn chunked_encode_str(bytes: &[u8], config: GeneralPurposeConfig) -> String {
         let mut s = String::new();
 
-        let mut sink = StringSink::from(&mut s);
-        let engine = GeneralPurpose::from(&STANDARD, config);
-        let encoder = ChunkedEncoder::from(&engine);
+        let mut sink = StringSink::new(&mut s);
+        let engine = GeneralPurpose::new(&STANDARD, config);
+        let encoder = ChunkedEncoder::new(&engine);
         encoder.encode(bytes, &mut sink).unwrap();
 
         s
@@ -219,9 +219,9 @@ pub mod tests {
 
     impl SinkTestHelper for StringSinkTestHelper {
         fn encode_to_string<E: Engine>(&self, engine: &E, bytes: &[u8]) -> String {
-            let encoder = ChunkedEncoder::from(engine);
+            let encoder = ChunkedEncoder::new(engine);
             let mut s = String::new();
-            let mut sink = StringSink::from(&mut s);
+            let mut sink = StringSink::new(&mut s);
             encoder.encode(bytes, &mut sink).unwrap();
 
             s

--- a/src/chunked_encoder.rs
+++ b/src/chunked_encoder.rs
@@ -41,7 +41,7 @@ impl<'e, E: Engine + ?Sized> ChunkedEncoder<'e, E> {
 
             let chunk = &bytes[input_index..(input_index + input_chunk_len)];
 
-            let mut b64_bytes_written = self.engine.inner_encode(chunk, &mut encode_buf);
+            let mut b64_bytes_written = self.engine.internal_encode(chunk, &mut encode_buf);
 
             input_index += input_chunk_len;
             let more_input_left = input_index < bytes.len();

--- a/src/chunked_encoder.rs
+++ b/src/chunked_encoder.rs
@@ -113,7 +113,7 @@ pub mod tests {
 
     use crate::alphabet::STANDARD;
     use crate::encode_engine_string;
-    use crate::engine::fast_portable::{FastPortable, FastPortableConfig, PAD};
+    use crate::engine::general_purpose::{GeneralPurpose, GeneralPurposeConfig, PAD};
     use crate::tests::random_engine;
 
     use super::*;
@@ -199,11 +199,11 @@ pub mod tests {
         }
     }
 
-    fn chunked_encode_str(bytes: &[u8], config: FastPortableConfig) -> String {
+    fn chunked_encode_str(bytes: &[u8], config: GeneralPurposeConfig) -> String {
         let mut s = String::new();
 
         let mut sink = StringSink::from(&mut s);
-        let engine = FastPortable::from(&STANDARD, config);
+        let engine = GeneralPurpose::from(&STANDARD, config);
         let encoder = ChunkedEncoder::from(&engine);
         encoder.encode(bytes, &mut sink).unwrap();
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -89,9 +89,9 @@ pub fn decode<T: AsRef<[u8]>>(input: T) -> Result<Vec<u8>, DecodeError> {
 ///    // custom engine setup
 ///    let bytes_url = base64::decode_engine(
 ///        "aGVsbG8gaW50ZXJuZXR-Cg",
-///        &base64::engine::fast_portable::FastPortable::from(
+///        &base64::engine::GeneralPurpose::from(
 ///            &base64::alphabet::URL_SAFE,
-///            base64::engine::fast_portable::NO_PAD),
+///            base64::engine::general_purpose::NO_PAD),
 ///
 ///    ).unwrap();
 ///    println!("{:?}", bytes_url);
@@ -119,10 +119,10 @@ pub fn decode_engine<E: Engine, T: AsRef<[u8]>>(
 ///# Example
 ///
 ///```rust
-///const URL_SAFE_ENGINE: base64::engine::fast_portable::FastPortable =
-///    base64::engine::fast_portable::FastPortable::from(
+///const URL_SAFE_ENGINE: base64::engine::GeneralPurpose =
+///    base64::engine::GeneralPurpose::from(
 ///        &base64::alphabet::URL_SAFE,
-///        base64::engine::fast_portable::PAD);
+///        base64::engine::general_purpose::PAD);
 ///
 ///fn main() {
 ///    let mut buffer = Vec::<u8>::new();
@@ -201,7 +201,7 @@ mod tests {
     use crate::{
         alphabet,
         encode::encode_engine_string,
-        engine::{fast_portable, fast_portable::FastPortable, Config},
+        engine::{general_purpose, GeneralPurpose, Config},
         tests::{assert_encode_sanity, random_engine},
     };
     use rand::{
@@ -358,7 +358,7 @@ mod tests {
 
     #[test]
     fn decode_engine_estimation_works_for_various_lengths() {
-        let engine = FastPortable::from(&alphabet::STANDARD, fast_portable::NO_PAD);
+        let engine = GeneralPurpose::from(&alphabet::STANDARD, general_purpose::NO_PAD);
         for num_prefix_quads in 0..100 {
             for suffix in &["AA", "AAA", "AAAA"] {
                 let mut prefix = "AAAA".repeat(num_prefix_quads);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,6 +1,6 @@
 use crate::engine::Engine;
 #[cfg(any(feature = "alloc", feature = "std", test))]
-use crate::engine::DEFAULT_ENGINE;
+use crate::engine::STANDARD;
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use alloc::vec::Vec;
 use core::fmt;
@@ -58,16 +58,16 @@ impl error::Error for DecodeError {
     }
 }
 
-///Decode base64 using the [default engine](DEFAULT_ENGINE).
+/// Decode base64 using the [`STANDARD` engine](STANDARD).
 ///
 /// See [Engine::decode].
 #[deprecated(since = "0.21.0", note = "Use Engine::decode")]
 #[cfg(any(feature = "alloc", feature = "std", test))]
 pub fn decode<T: AsRef<[u8]>>(input: T) -> Result<Vec<u8>, DecodeError> {
-    DEFAULT_ENGINE.decode(input)
+    STANDARD.decode(input)
 }
 
-///Decode from string reference as octets using the specified [Engine].
+/// Decode from string reference as octets using the specified [Engine].
 ///
 /// See [Engine::decode].
 ///Returns a `Result` containing a `Vec<u8>`.

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -200,7 +200,6 @@ mod tests {
     use super::*;
     use crate::{
         alphabet,
-        encode::encode_engine_string,
         engine::{general_purpose, Config, GeneralPurpose},
         tests::{assert_encode_sanity, random_engine},
     };
@@ -236,7 +235,7 @@ mod tests {
             }
 
             let engine = random_engine(&mut rng);
-            encode_engine_string(&orig_data, &mut encoded_data, &engine);
+            engine.encode_string(&orig_data, &mut encoded_data);
             assert_encode_sanity(&encoded_data, engine.config().encode_padding(), input_len);
 
             let prefix_len = prefix_len_range.sample(&mut rng);
@@ -291,7 +290,7 @@ mod tests {
             }
 
             let engine = random_engine(&mut rng);
-            encode_engine_string(&orig_data, &mut encoded_data, &engine);
+            engine.encode_string(&orig_data, &mut encoded_data);
             assert_encode_sanity(&encoded_data, engine.config().encode_padding(), input_len);
 
             // fill the buffer with random garbage, long enough to have some room before and after
@@ -342,7 +341,7 @@ mod tests {
             }
 
             let engine = random_engine(&mut rng);
-            encode_engine_string(&orig_data, &mut encoded_data, &engine);
+            engine.encode_string(&orig_data, &mut encoded_data);
             assert_encode_sanity(&encoded_data, engine.config().encode_padding(), input_len);
 
             decode_buf.resize(input_len, 0);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -89,7 +89,7 @@ pub fn decode<T: AsRef<[u8]>>(input: T) -> Result<Vec<u8>, DecodeError> {
 ///    // custom engine setup
 ///    let bytes_url = base64::decode_engine(
 ///        "aGVsbG8gaW50ZXJuZXR-Cg",
-///        &base64::engine::GeneralPurpose::from(
+///        &base64::engine::GeneralPurpose::new(
 ///            &base64::alphabet::URL_SAFE,
 ///            base64::engine::general_purpose::NO_PAD),
 ///
@@ -120,7 +120,7 @@ pub fn decode_engine<E: Engine, T: AsRef<[u8]>>(
 ///
 ///```rust
 ///const URL_SAFE_ENGINE: base64::engine::GeneralPurpose =
-///    base64::engine::GeneralPurpose::from(
+///    base64::engine::GeneralPurpose::new(
 ///        &base64::alphabet::URL_SAFE,
 ///        base64::engine::general_purpose::PAD);
 ///
@@ -201,7 +201,7 @@ mod tests {
     use crate::{
         alphabet,
         encode::encode_engine_string,
-        engine::{general_purpose, GeneralPurpose, Config},
+        engine::{general_purpose, Config, GeneralPurpose},
         tests::{assert_encode_sanity, random_engine},
     };
     use rand::{
@@ -358,7 +358,7 @@ mod tests {
 
     #[test]
     fn decode_engine_estimation_works_for_various_lengths() {
-        let engine = GeneralPurpose::from(&alphabet::STANDARD, general_purpose::NO_PAD);
+        let engine = GeneralPurpose::new(&alphabet::STANDARD, general_purpose::NO_PAD);
         for num_prefix_quads in 0..100 {
             for suffix in &["AA", "AAA", "AAAA"] {
                 let mut prefix = "AAAA".repeat(num_prefix_quads);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,4 +1,4 @@
-use crate::engine::{DecodeEstimate, Engine, STANDARD};
+use crate::engine::{general_purpose::STANDARD, DecodeEstimate, Engine};
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use alloc::vec::Vec;
 use core::fmt;

--- a/src/display.rs
+++ b/src/display.rs
@@ -5,7 +5,7 @@
 //! use base64::engine::DEFAULT_ENGINE;
 //!
 //! let data = vec![0x0, 0x1, 0x2, 0x3];
-//! let wrapper = Base64Display::from(&data, &DEFAULT_ENGINE);
+//! let wrapper = Base64Display::new(&data, &DEFAULT_ENGINE);
 //!
 //! assert_eq!("base64: AAECAw==", format!("base64: {}", wrapper));
 //! ```
@@ -23,10 +23,10 @@ pub struct Base64Display<'a, 'e, E: Engine> {
 
 impl<'a, 'e, E: Engine> Base64Display<'a, 'e, E> {
     /// Create a `Base64Display` with the provided engine.
-    pub fn from(bytes: &'a [u8], engine: &'e E) -> Base64Display<'a, 'e, E> {
+    pub fn new(bytes: &'a [u8], engine: &'e E) -> Base64Display<'a, 'e, E> {
         Base64Display {
             bytes,
-            chunked_encoder: ChunkedEncoder::from(engine),
+            chunked_encoder: ChunkedEncoder::new(engine),
         }
     }
 }
@@ -65,11 +65,11 @@ mod tests {
     fn basic_display() {
         assert_eq!(
             "~$Zm9vYmFy#*",
-            format!("~${}#*", Base64Display::from(b"foobar", &DEFAULT_ENGINE))
+            format!("~${}#*", Base64Display::new(b"foobar", &DEFAULT_ENGINE))
         );
         assert_eq!(
             "~$Zm9vYmFyZg==#*",
-            format!("~${}#*", Base64Display::from(b"foobarf", &DEFAULT_ENGINE))
+            format!("~${}#*", Base64Display::new(b"foobarf", &DEFAULT_ENGINE))
         );
     }
 
@@ -83,7 +83,7 @@ mod tests {
 
     impl SinkTestHelper for DisplaySinkTestHelper {
         fn encode_to_string<E: Engine>(&self, engine: &E, bytes: &[u8]) -> String {
-            format!("{}", Base64Display::from(bytes, engine))
+            format!("{}", Base64Display::new(bytes, engine))
         }
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -2,10 +2,10 @@
 //!
 //! ```
 //! use base64::display::Base64Display;
-//! use base64::engine::DEFAULT_ENGINE;
+//! use base64::engine::STANDARD;
 //!
 //! let data = vec![0x0, 0x1, 0x2, 0x3];
-//! let wrapper = Base64Display::new(&data, &DEFAULT_ENGINE);
+//! let wrapper = Base64Display::new(&data, &STANDARD);
 //!
 //! assert_eq!("base64: AAECAw==", format!("base64: {}", wrapper));
 //! ```
@@ -59,17 +59,17 @@ mod tests {
         chunked_encode_matches_normal_encode_random, SinkTestHelper,
     };
     use super::*;
-    use crate::engine::DEFAULT_ENGINE;
+    use crate::engine::STANDARD;
 
     #[test]
     fn basic_display() {
         assert_eq!(
             "~$Zm9vYmFy#*",
-            format!("~${}#*", Base64Display::new(b"foobar", &DEFAULT_ENGINE))
+            format!("~${}#*", Base64Display::new(b"foobar", &STANDARD))
         );
         assert_eq!(
             "~$Zm9vYmFyZg==#*",
-            format!("~${}#*", Base64Display::new(b"foobarf", &DEFAULT_ENGINE))
+            format!("~${}#*", Base64Display::new(b"foobarf", &STANDARD))
         );
     }
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,8 +1,7 @@
 //! Enables base64'd output anywhere you might use a `Display` implementation, like a format string.
 //!
 //! ```
-//! use base64::display::Base64Display;
-//! use base64::engine::STANDARD;
+//! use base64::{display::Base64Display, engine::general_purpose::STANDARD};
 //!
 //! let data = vec![0x0, 0x1, 0x2, 0x3];
 //! let wrapper = Base64Display::new(&data, &STANDARD);
@@ -59,7 +58,7 @@ mod tests {
         chunked_encode_matches_normal_encode_random, SinkTestHelper,
     };
     use super::*;
-    use crate::engine::STANDARD;
+    use crate::engine::general_purpose::STANDARD;
 
     #[test]
     fn basic_display() {

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -5,7 +5,7 @@ use core::fmt;
 use std::error;
 
 #[cfg(any(feature = "alloc", feature = "std", test))]
-use crate::engine::STANDARD;
+use crate::engine::general_purpose::STANDARD;
 use crate::engine::{Config, Engine};
 use crate::PAD_BYTE;
 
@@ -161,10 +161,7 @@ mod tests {
 
     use crate::{
         alphabet,
-        engine::{
-            general_purpose::{GeneralPurpose, NO_PAD},
-            STANDARD,
-        },
+        engine::general_purpose::{GeneralPurpose, NO_PAD, STANDARD},
         tests::{assert_encode_sanity, random_config, random_engine},
     };
     use rand::{

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -290,7 +290,7 @@ mod tests {
 
     #[test]
     fn encoded_size_overflow() {
-        assert_eq!(None, encoded_len(std::usize::MAX, true));
+        assert_eq!(None, encoded_len(usize::MAX, true));
     }
 
     #[test]
@@ -396,7 +396,7 @@ mod tests {
             );
 
             assert_encode_sanity(
-                std::str::from_utf8(&encoded_data[0..encoded_size]).unwrap(),
+                str::from_utf8(&encoded_data[0..encoded_size]).unwrap(),
                 engine.config().encode_padding(),
                 input_len,
             );
@@ -444,7 +444,7 @@ mod tests {
             );
 
             assert_encode_sanity(
-                std::str::from_utf8(&encoded_data[0..encoded_size]).unwrap(),
+                str::from_utf8(&encoded_data[0..encoded_size]).unwrap(),
                 engine.config().encode_padding(),
                 input_len,
             );

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -2,18 +2,18 @@
 use alloc::string::String;
 
 #[cfg(any(feature = "alloc", feature = "std", test))]
-use crate::engine::DEFAULT_ENGINE;
+use crate::engine::STANDARD;
 use crate::engine::{Config, Engine};
 use crate::PAD_BYTE;
 
-/// Encode arbitrary octets as base64 using the [default engine](DEFAULT_ENGINE).
+/// Encode arbitrary octets as base64 using the [`STANDARD` engine](STANDARD).
 ///
 /// See [Engine::encode].
 #[allow(unused)]
 #[deprecated(since = "0.21.0", note = "Use Engine::encode")]
 #[cfg(any(feature = "alloc", feature = "std", test))]
 pub fn encode<T: AsRef<[u8]>>(input: T) -> String {
-    DEFAULT_ENGINE.encode(input)
+    STANDARD.encode(input)
 }
 
 ///Encode arbitrary octets as base64 using the provided `Engine` into a new `String`.
@@ -133,10 +133,10 @@ mod tests {
     use super::*;
 
     use crate::{
-        alphabet::{IMAP_MUTF7, STANDARD, URL_SAFE},
+        alphabet,
         engine::{
             general_purpose::{GeneralPurpose, NO_PAD},
-            DEFAULT_ENGINE,
+            STANDARD,
         },
         tests::{assert_encode_sanity, random_config, random_engine},
     };
@@ -146,31 +146,31 @@ mod tests {
     };
     use std::str;
 
-    const URL_SAFE_NO_PAD_ENGINE: GeneralPurpose = GeneralPurpose::new(&URL_SAFE, NO_PAD);
+    const URL_SAFE_NO_PAD_ENGINE: GeneralPurpose = GeneralPurpose::new(&alphabet::URL_SAFE, NO_PAD);
 
     #[test]
     fn encoded_size_correct_standard() {
-        assert_encoded_length(0, 0, &DEFAULT_ENGINE, true);
+        assert_encoded_length(0, 0, &STANDARD, true);
 
-        assert_encoded_length(1, 4, &DEFAULT_ENGINE, true);
-        assert_encoded_length(2, 4, &DEFAULT_ENGINE, true);
-        assert_encoded_length(3, 4, &DEFAULT_ENGINE, true);
+        assert_encoded_length(1, 4, &STANDARD, true);
+        assert_encoded_length(2, 4, &STANDARD, true);
+        assert_encoded_length(3, 4, &STANDARD, true);
 
-        assert_encoded_length(4, 8, &DEFAULT_ENGINE, true);
-        assert_encoded_length(5, 8, &DEFAULT_ENGINE, true);
-        assert_encoded_length(6, 8, &DEFAULT_ENGINE, true);
+        assert_encoded_length(4, 8, &STANDARD, true);
+        assert_encoded_length(5, 8, &STANDARD, true);
+        assert_encoded_length(6, 8, &STANDARD, true);
 
-        assert_encoded_length(7, 12, &DEFAULT_ENGINE, true);
-        assert_encoded_length(8, 12, &DEFAULT_ENGINE, true);
-        assert_encoded_length(9, 12, &DEFAULT_ENGINE, true);
+        assert_encoded_length(7, 12, &STANDARD, true);
+        assert_encoded_length(8, 12, &STANDARD, true);
+        assert_encoded_length(9, 12, &STANDARD, true);
 
-        assert_encoded_length(54, 72, &DEFAULT_ENGINE, true);
+        assert_encoded_length(54, 72, &STANDARD, true);
 
-        assert_encoded_length(55, 76, &DEFAULT_ENGINE, true);
-        assert_encoded_length(56, 76, &DEFAULT_ENGINE, true);
-        assert_encoded_length(57, 76, &DEFAULT_ENGINE, true);
+        assert_encoded_length(55, 76, &STANDARD, true);
+        assert_encoded_length(56, 76, &STANDARD, true);
+        assert_encoded_length(57, 76, &STANDARD, true);
 
-        assert_encoded_length(58, 80, &DEFAULT_ENGINE, true);
+        assert_encoded_length(58, 80, &STANDARD, true);
     }
 
     #[test]
@@ -500,8 +500,8 @@ mod tests {
     #[test]
     fn encode_imap() {
         assert_eq!(
-            &GeneralPurpose::new(&IMAP_MUTF7, NO_PAD).encode(b"\xFB\xFF"),
-            &GeneralPurpose::new(&STANDARD, NO_PAD)
+            &GeneralPurpose::new(&alphabet::IMAP_MUTF7, NO_PAD).encode(b"\xFB\xFF"),
+            &GeneralPurpose::new(&alphabet::STANDARD, NO_PAD)
                 .encode(b"\xFB\xFF")
                 .replace('/', ",")
         );

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -27,10 +27,10 @@ pub fn encode<T: AsRef<[u8]>>(input: T) -> String {
 ///# Example
 ///
 ///```rust
-///const URL_SAFE_ENGINE: base64::engine::fast_portable::FastPortable =
-///    base64::engine::fast_portable::FastPortable::from(
+///const URL_SAFE_ENGINE: base64::engine::GeneralPurpose =
+///    base64::engine::GeneralPurpose::from(
 ///        &base64::alphabet::URL_SAFE,
-///        base64::engine::fast_portable::NO_PAD);
+///        base64::engine::general_purpose::NO_PAD);
 ///
 ///    let b64 = base64::encode_engine(
 ///        b"hello world~",
@@ -61,10 +61,10 @@ pub fn encode_engine<E: Engine, T: AsRef<[u8]>>(input: T, engine: &E) -> String 
 ///# Example
 ///
 ///```rust
-///const URL_SAFE_ENGINE: base64::engine::fast_portable::FastPortable =
-///    base64::engine::fast_portable::FastPortable::from(
+///const URL_SAFE_ENGINE: base64::engine::GeneralPurpose =
+///    base64::engine::GeneralPurpose::from(
 ///        &base64::alphabet::URL_SAFE,
-///        base64::engine::fast_portable::NO_PAD);
+///        base64::engine::general_purpose::NO_PAD);
 ///fn main() {
 ///    let mut buf = String::new();
 ///    base64::encode_engine_string(
@@ -223,21 +223,20 @@ pub fn add_padding(input_len: usize, output: &mut [u8]) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        decode::decode_engine_vec,
-        tests::{assert_encode_sanity, random_config},
-    };
 
-    use crate::alphabet::{IMAP_MUTF7, STANDARD, URL_SAFE};
-    use crate::engine::fast_portable::{FastPortable, NO_PAD};
-    use crate::tests::random_engine;
+    use crate::{
+        alphabet::{IMAP_MUTF7, STANDARD, URL_SAFE},
+        decode::decode_engine_vec,
+        engine::general_purpose::{GeneralPurpose, NO_PAD},
+        tests::{assert_encode_sanity, random_config, random_engine},
+    };
     use rand::{
         distributions::{Distribution, Uniform},
         Rng, SeedableRng,
     };
     use std::str;
 
-    const URL_SAFE_NO_PAD_ENGINE: FastPortable = FastPortable::from(&URL_SAFE, NO_PAD);
+    const URL_SAFE_NO_PAD_ENGINE: GeneralPurpose = GeneralPurpose::from(&URL_SAFE, NO_PAD);
 
     #[test]
     fn encoded_size_correct_standard() {
@@ -585,8 +584,8 @@ mod tests {
     #[test]
     fn encode_imap() {
         assert_eq!(
-            encode_engine(b"\xFB\xFF", &FastPortable::from(&IMAP_MUTF7, NO_PAD)),
-            encode_engine(b"\xFB\xFF", &FastPortable::from(&STANDARD, NO_PAD)).replace('/', ",")
+            encode_engine(b"\xFB\xFF", &GeneralPurpose::from(&IMAP_MUTF7, NO_PAD)),
+            encode_engine(b"\xFB\xFF", &GeneralPurpose::from(&STANDARD, NO_PAD)).replace('/', ",")
         );
     }
 }

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -28,7 +28,7 @@ pub fn encode<T: AsRef<[u8]>>(input: T) -> String {
 ///
 ///```rust
 ///const URL_SAFE_ENGINE: base64::engine::GeneralPurpose =
-///    base64::engine::GeneralPurpose::from(
+///    base64::engine::GeneralPurpose::new(
 ///        &base64::alphabet::URL_SAFE,
 ///        base64::engine::general_purpose::NO_PAD);
 ///
@@ -62,7 +62,7 @@ pub fn encode_engine<E: Engine, T: AsRef<[u8]>>(input: T, engine: &E) -> String 
 ///
 ///```rust
 ///const URL_SAFE_ENGINE: base64::engine::GeneralPurpose =
-///    base64::engine::GeneralPurpose::from(
+///    base64::engine::GeneralPurpose::new(
 ///        &base64::alphabet::URL_SAFE,
 ///        base64::engine::general_purpose::NO_PAD);
 ///fn main() {
@@ -90,8 +90,8 @@ pub fn encode_engine_string<E: Engine, T: AsRef<[u8]>>(
     let input_bytes = input.as_ref();
 
     {
-        let mut sink = chunked_encoder::StringSink::from(output_buf);
-        let encoder = chunked_encoder::ChunkedEncoder::from(engine);
+        let mut sink = chunked_encoder::StringSink::new(output_buf);
+        let encoder = chunked_encoder::ChunkedEncoder::new(engine);
 
         encoder
             .encode(input_bytes, &mut sink)
@@ -236,7 +236,7 @@ mod tests {
     };
     use std::str;
 
-    const URL_SAFE_NO_PAD_ENGINE: GeneralPurpose = GeneralPurpose::from(&URL_SAFE, NO_PAD);
+    const URL_SAFE_NO_PAD_ENGINE: GeneralPurpose = GeneralPurpose::new(&URL_SAFE, NO_PAD);
 
     #[test]
     fn encoded_size_correct_standard() {
@@ -584,8 +584,8 @@ mod tests {
     #[test]
     fn encode_imap() {
         assert_eq!(
-            encode_engine(b"\xFB\xFF", &GeneralPurpose::from(&IMAP_MUTF7, NO_PAD)),
-            encode_engine(b"\xFB\xFF", &GeneralPurpose::from(&STANDARD, NO_PAD)).replace('/', ",")
+            encode_engine(b"\xFB\xFF", &GeneralPurpose::new(&IMAP_MUTF7, NO_PAD)),
+            encode_engine(b"\xFB\xFF", &GeneralPurpose::new(&STANDARD, NO_PAD)).replace('/', ",")
         );
     }
 }

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -134,7 +134,6 @@ mod tests {
 
     use crate::{
         alphabet::{IMAP_MUTF7, STANDARD, URL_SAFE},
-        decode::decode_engine_vec,
         engine::{
             general_purpose::{GeneralPurpose, NO_PAD},
             DEFAULT_ENGINE,
@@ -262,7 +261,9 @@ mod tests {
 
             assert_eq!(prefix, encoded_data_with_prefix);
 
-            decode_engine_vec(&encoded_data_no_prefix, &mut decoded, &engine).unwrap();
+            engine
+                .decode_vec(&encoded_data_no_prefix, &mut decoded)
+                .unwrap();
             assert_eq!(orig_data, decoded);
         }
     }
@@ -317,7 +318,9 @@ mod tests {
                 &encoded_data_original_state[encoded_size..]
             );
 
-            decode_engine_vec(&encoded_data[0..encoded_size], &mut decoded, &engine).unwrap();
+            engine
+                .decode_vec(&encoded_data[0..encoded_size], &mut decoded)
+                .unwrap();
             assert_eq!(orig_data, decoded);
         }
     }
@@ -360,7 +363,9 @@ mod tests {
                 input_len,
             );
 
-            decode_engine_vec(&encoded_data[0..encoded_size], &mut decoded, &engine).unwrap();
+            engine
+                .decode_vec(&encoded_data[0..encoded_size], &mut decoded)
+                .unwrap();
             assert_eq!(orig_data, decoded);
         }
     }

--- a/src/engine/general_purpose/decode.rs
+++ b/src/engine/general_purpose/decode.rs
@@ -327,14 +327,14 @@ fn write_u64(output: &mut [u8], value: u64) {
 mod tests {
     use super::*;
 
-    use crate::engine::DEFAULT_ENGINE;
+    use crate::engine::STANDARD;
 
     #[test]
     fn decode_chunk_precise_writes_only_6_bytes() {
         let input = b"Zm9vYmFy"; // "foobar"
         let mut output = [0_u8, 1, 2, 3, 4, 5, 6, 7];
 
-        decode_chunk_precise(&input[..], 0, &DEFAULT_ENGINE.decode_table, &mut output).unwrap();
+        decode_chunk_precise(&input[..], 0, &STANDARD.decode_table, &mut output).unwrap();
         assert_eq!(&vec![b'f', b'o', b'o', b'b', b'a', b'r', 6, 7], &output);
     }
 
@@ -343,7 +343,7 @@ mod tests {
         let input = b"Zm9vYmFy"; // "foobar"
         let mut output = [0_u8, 1, 2, 3, 4, 5, 6, 7];
 
-        decode_chunk(&input[..], 0, &DEFAULT_ENGINE.decode_table, &mut output).unwrap();
+        decode_chunk(&input[..], 0, &STANDARD.decode_table, &mut output).unwrap();
         assert_eq!(&vec![b'f', b'o', b'o', b'b', b'a', b'r', 0, 0], &output);
     }
 }

--- a/src/engine/general_purpose/decode.rs
+++ b/src/engine/general_purpose/decode.rs
@@ -1,5 +1,5 @@
 use crate::{
-    engine::{fast_portable::INVALID_VALUE, DecodeEstimate, DecodePaddingMode},
+    engine::{general_purpose::INVALID_VALUE, DecodeEstimate, DecodePaddingMode},
     DecodeError, PAD_BYTE,
 };
 
@@ -22,12 +22,12 @@ const DECODED_BLOCK_LEN: usize =
     CHUNKS_PER_FAST_LOOP_BLOCK * DECODED_CHUNK_LEN + DECODED_CHUNK_SUFFIX;
 
 #[doc(hidden)]
-pub struct FastPortableEstimate {
+pub struct GeneralPurposeEstimate {
     /// Total number of decode chunks, including a possibly partial last chunk
     num_chunks: usize,
 }
 
-impl FastPortableEstimate {
+impl GeneralPurposeEstimate {
     pub(crate) fn from(input_len: usize) -> Self {
         Self {
             num_chunks: num_chunks(input_len),
@@ -35,7 +35,7 @@ impl FastPortableEstimate {
     }
 }
 
-impl DecodeEstimate for FastPortableEstimate {
+impl DecodeEstimate for GeneralPurposeEstimate {
     fn decoded_length_estimate(&self) -> usize {
         self.num_chunks
             .checked_mul(DECODED_CHUNK_LEN)
@@ -51,7 +51,7 @@ impl DecodeEstimate for FastPortableEstimate {
 #[inline]
 pub(crate) fn decode_helper(
     input: &[u8],
-    estimate: FastPortableEstimate,
+    estimate: GeneralPurposeEstimate,
     output: &mut [u8],
     decode_table: &[u8; 256],
     decode_allow_trailing_bits: bool,

--- a/src/engine/general_purpose/decode.rs
+++ b/src/engine/general_purpose/decode.rs
@@ -326,7 +326,7 @@ fn write_u64(output: &mut [u8], value: u64) {
 mod tests {
     use super::*;
 
-    use crate::engine::STANDARD;
+    use crate::engine::general_purpose::STANDARD;
 
     #[test]
     fn decode_chunk_precise_writes_only_6_bytes() {

--- a/src/engine/general_purpose/decode.rs
+++ b/src/engine/general_purpose/decode.rs
@@ -28,7 +28,7 @@ pub struct GeneralPurposeEstimate {
 }
 
 impl GeneralPurposeEstimate {
-    pub(crate) fn from(input_len: usize) -> Self {
+    pub(crate) fn new(input_len: usize) -> Self {
         Self {
             num_chunks: num_chunks(input_len),
         }

--- a/src/engine/general_purpose/decode_suffix.rs
+++ b/src/engine/general_purpose/decode_suffix.rs
@@ -1,5 +1,5 @@
 use crate::{
-    engine::{fast_portable::INVALID_VALUE, DecodePaddingMode},
+    engine::{general_purpose::INVALID_VALUE, DecodePaddingMode},
     DecodeError, PAD_BYTE,
 };
 

--- a/src/engine/general_purpose/mod.rs
+++ b/src/engine/general_purpose/mod.rs
@@ -1,5 +1,6 @@
 //! Provides the [GeneralPurpose] engine and associated config types.
 use crate::{
+    alphabet,
     alphabet::Alphabet,
     engine::{Config, DecodePaddingMode},
     DecodeError,
@@ -323,6 +324,15 @@ impl Config for GeneralPurposeConfig {
         self.encode_padding
     }
 }
+
+/// A [GeneralPurpose] engine using the [crate::alphabet::STANDARD] base64 alphabet and [crate::engine::general_purpose::PAD] config.
+pub const STANDARD: GeneralPurpose = GeneralPurpose::new(&alphabet::STANDARD, PAD);
+
+/// A [GeneralPurpose] engine using the [crate::alphabet::URL_SAFE] base64 alphabet and [crate::engine::general_purpose::PAD] config.
+pub const URL_SAFE: GeneralPurpose = GeneralPurpose::new(&alphabet::URL_SAFE, PAD);
+
+/// A [GeneralPurpose] engine using the [crate::alphabet::URL_SAFE] base64 alphabet and [crate::engine::general_purpose::NO_PAD] config.
+pub const URL_SAFE_NO_PAD: GeneralPurpose = GeneralPurpose::new(&alphabet::URL_SAFE, NO_PAD);
 
 /// Include padding bytes when encoding, and require that they be present when decoding.
 ///

--- a/src/engine/general_purpose/mod.rs
+++ b/src/engine/general_purpose/mod.rs
@@ -41,7 +41,7 @@ impl super::Engine for GeneralPurpose {
     type Config = GeneralPurposeConfig;
     type DecodeEstimate = GeneralPurposeEstimate;
 
-    fn encode(&self, input: &[u8], output: &mut [u8]) -> usize {
+    fn inner_encode(&self, input: &[u8], output: &mut [u8]) -> usize {
         let mut input_index: usize = 0;
 
         const BLOCKS_PER_FAST_LOOP: usize = 4;

--- a/src/engine/general_purpose/mod.rs
+++ b/src/engine/general_purpose/mod.rs
@@ -28,7 +28,7 @@ impl GeneralPurpose {
     ///
     /// While not very expensive to initialize, ideally these should be cached
     /// if the engine will be used repeatedly.
-    pub const fn from(alphabet: &Alphabet, config: GeneralPurposeConfig) -> Self {
+    pub const fn new(alphabet: &Alphabet, config: GeneralPurposeConfig) -> Self {
         Self {
             encode_table: encode_table(alphabet),
             decode_table: decode_table(alphabet),
@@ -161,7 +161,7 @@ impl super::Engine for GeneralPurpose {
     }
 
     fn decoded_length_estimate(&self, input_len: usize) -> Self::DecodeEstimate {
-        GeneralPurposeEstimate::from(input_len)
+        GeneralPurposeEstimate::new(input_len)
     }
 
     fn decode(

--- a/src/engine/general_purpose/mod.rs
+++ b/src/engine/general_purpose/mod.rs
@@ -42,7 +42,7 @@ impl super::Engine for GeneralPurpose {
     type Config = GeneralPurposeConfig;
     type DecodeEstimate = GeneralPurposeEstimate;
 
-    fn inner_encode(&self, input: &[u8], output: &mut [u8]) -> usize {
+    fn internal_encode(&self, input: &[u8], output: &mut [u8]) -> usize {
         let mut input_index: usize = 0;
 
         const BLOCKS_PER_FAST_LOOP: usize = 4;
@@ -161,11 +161,11 @@ impl super::Engine for GeneralPurpose {
         output_index
     }
 
-    fn decoded_length_estimate(&self, input_len: usize) -> Self::DecodeEstimate {
+    fn internal_decoded_len_estimate(&self, input_len: usize) -> Self::DecodeEstimate {
         GeneralPurposeEstimate::new(input_len)
     }
 
-    fn inner_decode(
+    fn internal_decode(
         &self,
         input: &[u8],
         output: &mut [u8],
@@ -327,6 +327,9 @@ impl Config for GeneralPurposeConfig {
 
 /// A [GeneralPurpose] engine using the [crate::alphabet::STANDARD] base64 alphabet and [crate::engine::general_purpose::PAD] config.
 pub const STANDARD: GeneralPurpose = GeneralPurpose::new(&alphabet::STANDARD, PAD);
+
+/// A [GeneralPurpose] engine using the [crate::alphabet::STANDARD] base64 alphabet and [crate::engine::general_purpose::NO_PAD] config.
+pub const STANDARD_NO_PAD: GeneralPurpose = GeneralPurpose::new(&alphabet::STANDARD, NO_PAD);
 
 /// A [GeneralPurpose] engine using the [crate::alphabet::URL_SAFE] base64 alphabet and [crate::engine::general_purpose::PAD] config.
 pub const URL_SAFE: GeneralPurpose = GeneralPurpose::new(&alphabet::URL_SAFE, PAD);

--- a/src/engine/general_purpose/mod.rs
+++ b/src/engine/general_purpose/mod.rs
@@ -164,7 +164,7 @@ impl super::Engine for GeneralPurpose {
         GeneralPurposeEstimate::new(input_len)
     }
 
-    fn decode(
+    fn inner_decode(
         &self,
         input: &[u8],
         output: &mut [u8],

--- a/src/engine/general_purpose/mod.rs
+++ b/src/engine/general_purpose/mod.rs
@@ -237,7 +237,7 @@ fn read_u64(s: &[u8]) -> u64 {
 ///
 /// The constants [PAD] and [NO_PAD] cover most use cases.
 ///
-/// To specify the characters used, see [crate::alphabet::Alphabet].
+/// To specify the characters used, see [Alphabet].
 #[derive(Clone, Copy, Debug)]
 pub struct GeneralPurposeConfig {
     encode_padding: bool,
@@ -325,16 +325,16 @@ impl Config for GeneralPurposeConfig {
     }
 }
 
-/// A [GeneralPurpose] engine using the [crate::alphabet::STANDARD] base64 alphabet and [crate::engine::general_purpose::PAD] config.
+/// A [GeneralPurpose] engine using the [alphabet::STANDARD] base64 alphabet and [PAD] config.
 pub const STANDARD: GeneralPurpose = GeneralPurpose::new(&alphabet::STANDARD, PAD);
 
-/// A [GeneralPurpose] engine using the [crate::alphabet::STANDARD] base64 alphabet and [crate::engine::general_purpose::NO_PAD] config.
+/// A [GeneralPurpose] engine using the [alphabet::STANDARD] base64 alphabet and [NO_PAD] config.
 pub const STANDARD_NO_PAD: GeneralPurpose = GeneralPurpose::new(&alphabet::STANDARD, NO_PAD);
 
-/// A [GeneralPurpose] engine using the [crate::alphabet::URL_SAFE] base64 alphabet and [crate::engine::general_purpose::PAD] config.
+/// A [GeneralPurpose] engine using the [alphabet::URL_SAFE] base64 alphabet and [PAD] config.
 pub const URL_SAFE: GeneralPurpose = GeneralPurpose::new(&alphabet::URL_SAFE, PAD);
 
-/// A [GeneralPurpose] engine using the [crate::alphabet::URL_SAFE] base64 alphabet and [crate::engine::general_purpose::NO_PAD] config.
+/// A [GeneralPurpose] engine using the [alphabet::URL_SAFE] base64 alphabet and [NO_PAD] config.
 pub const URL_SAFE_NO_PAD: GeneralPurpose = GeneralPurpose::new(&alphabet::URL_SAFE, NO_PAD);
 
 /// Include padding bytes when encoding, and require that they be present when decoding.

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -100,7 +100,7 @@ pub trait DecodeEstimate {
 
 /// A [GeneralPurpose] engine using the [crate::alphabet::STANDARD] base64 alphabet and [crate::engine::general_purpose::PAD] config.
 pub const DEFAULT_ENGINE: GeneralPurpose =
-    GeneralPurpose::from(&alphabet::STANDARD, general_purpose::PAD);
+    GeneralPurpose::new(&alphabet::STANDARD, general_purpose::PAD);
 
 /// Controls how pad bytes are handled when decoding.
 ///

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -23,7 +23,7 @@ pub use general_purpose::{
 /// An `Engine` provides low-level encoding and decoding operations that all other higher-level parts of the API use. Users of the library will generally not need to implement this.
 ///
 /// Different implementations offer different characteristics. The library currently ships with
-/// a general-purpose [GeneralPurpose] impl that offers good speed and works on any CPU, with more choices
+/// [GeneralPurpose] that offers good speed and works on any CPU, with more choices
 /// coming later, like a constant-time one when side channel resistance is called for, and vendor-specific vectorized ones for more speed.
 ///
 /// See [STANDARD] if you just want standard base64. Otherwise, when possible, it's

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,8 +1,7 @@
 //! Provides the [Engine] abstraction and out of the box implementations.
-use crate::engine::fast_portable::FastPortable;
 use crate::{alphabet, DecodeError};
 
-pub mod fast_portable;
+pub mod general_purpose;
 
 #[cfg(test)]
 mod naive;
@@ -10,10 +9,12 @@ mod naive;
 #[cfg(test)]
 mod tests;
 
+pub use general_purpose::{GeneralPurpose, GeneralPurposeConfig};
+
 /// An `Engine` provides low-level encoding and decoding operations that all other higher-level parts of the API use. Users of the library will generally not need to implement this.
 ///
 /// Different implementations offer different characteristics. The library currently ships with
-/// a general-purpose [FastPortable] impl that offers good speed and works on any CPU, with more choices
+/// a general-purpose [GeneralPurpose] impl that offers good speed and works on any CPU, with more choices
 /// coming later, like a constant-time one when side channel resistance is called for, and vendor-specific vectorized ones for more speed.
 ///
 /// See [DEFAULT_ENGINE] if you just want standard base64. Otherwise, when possible, it's
@@ -97,9 +98,9 @@ pub trait DecodeEstimate {
     fn decoded_length_estimate(&self) -> usize;
 }
 
-/// A [FastPortable] engine using the [crate::alphabet::STANDARD] base64 alphabet and [crate::engine::fast_portable::PAD] config.
-pub const DEFAULT_ENGINE: FastPortable =
-    FastPortable::from(&alphabet::STANDARD, fast_portable::PAD);
+/// A [GeneralPurpose] engine using the [crate::alphabet::STANDARD] base64 alphabet and [crate::engine::general_purpose::PAD] config.
+pub const DEFAULT_ENGINE: GeneralPurpose =
+    GeneralPurpose::from(&alphabet::STANDARD, general_purpose::PAD);
 
 /// Controls how pad bytes are handled when decoding.
 ///

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,5 +1,10 @@
 //! Provides the [Engine] abstraction and out of the box implementations.
-use crate::{alphabet, DecodeError};
+#[cfg(any(feature = "alloc", feature = "std", test))]
+use crate::chunked_encoder;
+use crate::{alphabet, encode::encode_with_padding, encoded_len, DecodeError};
+
+#[cfg(any(feature = "alloc", feature = "std", test))]
+use alloc::{string::String, vec};
 
 pub mod general_purpose;
 
@@ -30,6 +35,8 @@ pub trait Engine: Send + Sync {
     /// The decode estimate used by this engine
     type DecodeEstimate: DecodeEstimate;
 
+    /// This is not meant to be called directly. See the other `encode*` functions on this trait.
+    ///
     /// Encode the `input` bytes into the `output` buffer based on the mapping in `encode_table`.
     ///
     /// `output` will be long enough to hold the encoded data.
@@ -39,7 +46,7 @@ pub trait Engine: Send + Sync {
     /// No padding should be written; that is handled separately.
     ///
     /// Must not write any bytes into the output slice other than the encoded data.
-    fn encode(&self, input: &[u8], output: &mut [u8]) -> usize;
+    fn inner_encode(&self, input: &[u8], output: &mut [u8]) -> usize;
 
     /// As an optimization to prevent the decoded length from being calculated twice, it is
     /// sometimes helpful to have a conservative estimate of the decoded size before doing the
@@ -72,6 +79,106 @@ pub trait Engine: Send + Sync {
 
     /// Returns the config for this engine.
     fn config(&self) -> &Self::Config;
+
+    ///Encode arbitrary octets as base64 using the provided `Engine`.
+    ///Returns a `String`.
+    ///
+    ///# Example
+    ///
+    ///```rust
+    ///use base64::Engine as _;
+    ///const URL_SAFE_ENGINE: base64::engine::GeneralPurpose =
+    ///    base64::engine::GeneralPurpose::new(
+    ///        &base64::alphabet::URL_SAFE,
+    ///        base64::engine::general_purpose::NO_PAD);
+    ///
+    ///    let b64 = base64::engine::DEFAULT_ENGINE.encode(b"hello world~");
+    ///    println!("{}", b64);
+    ///
+    ///    //////let b64_url = URL_SAFE_ENGINE.encode(b"hello internet~");
+    #[cfg(any(feature = "alloc", feature = "std", test))]
+    fn encode<T: AsRef<[u8]>>(&self, input: T) -> String {
+        let encoded_size = encoded_len(input.as_ref().len(), self.config().encode_padding())
+            .expect("integer overflow when calculating buffer size");
+        let mut buf = vec![0; encoded_size];
+
+        encode_with_padding(input.as_ref(), &mut buf[..], self, encoded_size);
+
+        String::from_utf8(buf).expect("Invalid UTF8")
+    }
+
+    ///Encode arbitrary octets as base64 into a supplied `String`.
+    ///Writes into the supplied `String`, which may allocate if its internal buffer isn't big enough.
+    ///
+    ///# Example
+    ///
+    ///```rust
+    ///use base64::Engine as _;
+    ///const URL_SAFE_ENGINE: base64::engine::GeneralPurpose =
+    ///    base64::engine::GeneralPurpose::new(
+    ///        &base64::alphabet::URL_SAFE,
+    ///        base64::engine::general_purpose::NO_PAD);
+    ///fn main() {
+    ///    let mut buf = String::new();
+    ///    base64::engine::DEFAULT_ENGINE.encode_string(b"hello world~", &mut buf);
+    ///    println!("{}", buf);
+    ///
+    ///    buf.clear();
+    ///    URL_SAFE_ENGINE.encode_string(b"hello internet~", &mut buf);
+    ///    println!("{}", buf);
+    ///}
+    ///```
+    #[cfg(any(feature = "alloc", feature = "std", test))]
+    fn encode_string<T: AsRef<[u8]>>(&self, input: T, output_buf: &mut String) {
+        let input_bytes = input.as_ref();
+
+        {
+            let mut sink = chunked_encoder::StringSink::new(output_buf);
+
+            chunked_encoder::ChunkedEncoder::new(self)
+                .encode(input_bytes, &mut sink)
+                .expect("Writing to a String shouldn't fail");
+        }
+    }
+
+    /// Encode arbitrary octets as base64 into a supplied slice.
+    /// Writes into the supplied output buffer.
+    ///
+    /// This is useful if you wish to avoid allocation entirely (e.g. encoding into a stack-resident
+    /// or statically-allocated buffer).
+    ///
+    /// # Panics
+    ///
+    /// If `output` is too small to hold the encoded version of `input`, a panic will result.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use base64::Engine as _;
+    /// let s = b"hello internet!";
+    /// let mut buf = Vec::new();
+    /// // make sure we'll have a slice big enough for base64 + padding
+    /// buf.resize(s.len() * 4 / 3 + 4, 0);
+    ///
+    /// let bytes_written = base64::engine::DEFAULT_ENGINE.encode_slice(s, &mut buf);
+    ///
+    /// // shorten our vec down to just what was written
+    /// buf.truncate(bytes_written);
+    ///
+    /// assert_eq!(s, base64::decode(&buf).unwrap().as_slice());
+    /// ```
+    fn encode_slice<T: AsRef<[u8]>>(&self, input: T, output_buf: &mut [u8]) -> usize {
+        let input_bytes = input.as_ref();
+
+        let encoded_size = encoded_len(input_bytes.len(), self.config().encode_padding())
+            .expect("usize overflow when calculating buffer size");
+
+        let b64_output = &mut output_buf[0..encoded_size];
+
+        encode_with_padding(input_bytes, b64_output, self, encoded_size);
+
+        encoded_size
+    }
 }
 
 /// The minimal level of configuration that engines must support.

--- a/src/engine/naive.rs
+++ b/src/engine/naive.rs
@@ -43,7 +43,7 @@ impl Engine for Naive {
     type Config = NaiveConfig;
     type DecodeEstimate = NaiveEstimate;
 
-    fn encode(&self, input: &[u8], output: &mut [u8]) -> usize {
+    fn inner_encode(&self, input: &[u8], output: &mut [u8]) -> usize {
         // complete chunks first
 
         const LOW_SIX_BITS: u32 = 0x3F;

--- a/src/engine/naive.rs
+++ b/src/engine/naive.rs
@@ -43,7 +43,7 @@ impl Engine for Naive {
     type Config = NaiveConfig;
     type DecodeEstimate = NaiveEstimate;
 
-    fn inner_encode(&self, input: &[u8], output: &mut [u8]) -> usize {
+    fn internal_encode(&self, input: &[u8], output: &mut [u8]) -> usize {
         // complete chunks first
 
         const LOW_SIX_BITS: u32 = 0x3F;
@@ -103,11 +103,11 @@ impl Engine for Naive {
         output_index
     }
 
-    fn decoded_length_estimate(&self, input_len: usize) -> Self::DecodeEstimate {
+    fn internal_decoded_len_estimate(&self, input_len: usize) -> Self::DecodeEstimate {
         NaiveEstimate::new(input_len)
     }
 
-    fn inner_decode(
+    fn internal_decode(
         &self,
         input: &[u8],
         output: &mut [u8],
@@ -183,7 +183,7 @@ impl Engine for Naive {
 pub struct NaiveEstimate {
     /// remainder from dividing input by `Naive::DECODE_CHUNK_SIZE`
     rem: usize,
-    /// Number of complete `Naive::DECODE_CHUNK_SIZE`-length chunks
+    /// Length of input that is in complete `Naive::DECODE_CHUNK_SIZE`-length chunks
     complete_chunk_len: usize,
 }
 
@@ -200,8 +200,8 @@ impl NaiveEstimate {
 }
 
 impl DecodeEstimate for NaiveEstimate {
-    fn decoded_length_estimate(&self) -> usize {
-        (self.complete_chunk_len + 1) * 3
+    fn decoded_len_estimate(&self) -> usize {
+        ((self.complete_chunk_len / 4) + ((self.rem > 0) as usize)) * 3
     }
 }
 

--- a/src/engine/naive.rs
+++ b/src/engine/naive.rs
@@ -107,7 +107,7 @@ impl Engine for Naive {
         NaiveEstimate::new(input_len)
     }
 
-    fn decode(
+    fn inner_decode(
         &self,
         input: &[u8],
         output: &mut [u8],

--- a/src/engine/naive.rs
+++ b/src/engine/naive.rs
@@ -1,7 +1,7 @@
 use crate::{
     alphabet::Alphabet,
     engine::{
-        fast_portable::{self, decode_table, encode_table},
+        general_purpose::{self, decode_table, encode_table},
         Config, DecodeEstimate, DecodePaddingMode, Engine,
     },
     DecodeError, PAD_BYTE,
@@ -31,7 +31,7 @@ impl Naive {
     fn decode_byte_into_u32(&self, offset: usize, byte: u8) -> Result<u32, DecodeError> {
         let decoded = self.decode_table[byte as usize];
 
-        if decoded == fast_portable::INVALID_VALUE {
+        if decoded == general_purpose::INVALID_VALUE {
             return Err(DecodeError::InvalidByte(offset, byte));
         }
 
@@ -117,7 +117,7 @@ impl Engine for Naive {
             // trailing whitespace is so common that it's worth it to check the last byte to
             // possibly return a better error message
             if let Some(b) = input.last() {
-                if *b != PAD_BYTE && self.decode_table[*b as usize] == fast_portable::INVALID_VALUE
+                if *b != PAD_BYTE && self.decode_table[*b as usize] == general_purpose::INVALID_VALUE
                 {
                     return Err(DecodeError::InvalidByte(input.len() - 1, *b));
                 }
@@ -163,7 +163,7 @@ impl Engine for Naive {
             }
         }
 
-        fast_portable::decode_suffix::decode_suffix(
+        general_purpose::decode_suffix::decode_suffix(
             input,
             input_index,
             output,

--- a/src/engine/naive.rs
+++ b/src/engine/naive.rs
@@ -20,7 +20,7 @@ impl Naive {
     const ENCODE_INPUT_CHUNK_SIZE: usize = 3;
     const DECODE_INPUT_CHUNK_SIZE: usize = 4;
 
-    pub const fn from(alphabet: &Alphabet, config: NaiveConfig) -> Self {
+    pub const fn new(alphabet: &Alphabet, config: NaiveConfig) -> Self {
         Self {
             encode_table: encode_table(alphabet),
             decode_table: decode_table(alphabet),
@@ -104,7 +104,7 @@ impl Engine for Naive {
     }
 
     fn decoded_length_estimate(&self, input_len: usize) -> Self::DecodeEstimate {
-        NaiveEstimate::from(input_len)
+        NaiveEstimate::new(input_len)
     }
 
     fn decode(
@@ -117,7 +117,8 @@ impl Engine for Naive {
             // trailing whitespace is so common that it's worth it to check the last byte to
             // possibly return a better error message
             if let Some(b) = input.last() {
-                if *b != PAD_BYTE && self.decode_table[*b as usize] == general_purpose::INVALID_VALUE
+                if *b != PAD_BYTE
+                    && self.decode_table[*b as usize] == general_purpose::INVALID_VALUE
                 {
                     return Err(DecodeError::InvalidByte(input.len() - 1, *b));
                 }
@@ -187,7 +188,7 @@ pub struct NaiveEstimate {
 }
 
 impl NaiveEstimate {
-    fn from(input_len: usize) -> Self {
+    fn new(input_len: usize) -> Self {
         let rem = input_len % Naive::DECODE_INPUT_CHUNK_SIZE;
         let complete_chunk_len = input_len - rem;
 

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -11,7 +11,7 @@ use std::{collections, fmt};
 use crate::{
     alphabet::{Alphabet, STANDARD},
     decode_engine, encode, encode_engine_slice,
-    engine::{fast_portable, naive, Config, DecodePaddingMode, Engine},
+    engine::{general_purpose, naive, Config, DecodePaddingMode, Engine},
     tests::{assert_encode_sanity, random_alphabet, random_config},
     DecodeError, PAD_BYTE,
 };
@@ -19,7 +19,7 @@ use crate::{
 // the case::foo syntax includes the "foo" in the generated test method names
 #[template]
 #[rstest(engine_wrapper,
-case::fast_portable(FastPortableWrapper {}),
+case::general_purpose(GeneralPurposeWrapper {}),
 case::naive(NaiveWrapper {}),
 )]
 fn all_engines<E: EngineWrapper>(engine_wrapper: E) {}
@@ -1199,19 +1199,19 @@ trait EngineWrapper {
     fn random_alphabet<R: rand::Rng>(rng: &mut R, alphabet: &Alphabet) -> Self::Engine;
 }
 
-struct FastPortableWrapper {}
+struct GeneralPurposeWrapper {}
 
-impl EngineWrapper for FastPortableWrapper {
-    type Engine = fast_portable::FastPortable;
+impl EngineWrapper for GeneralPurposeWrapper {
+    type Engine = general_purpose::GeneralPurpose;
 
     fn standard() -> Self::Engine {
-        fast_portable::FastPortable::from(&STANDARD, fast_portable::PAD)
+        general_purpose::GeneralPurpose::from(&STANDARD, general_purpose::PAD)
     }
 
     fn standard_unpadded() -> Self::Engine {
-        fast_portable::FastPortable::from(
+        general_purpose::GeneralPurpose::from(
             &STANDARD,
-            fast_portable::NO_PAD.with_decode_padding_mode(DecodePaddingMode::RequireNone),
+            general_purpose::NO_PAD.with_decode_padding_mode(DecodePaddingMode::RequireNone),
         )
     }
 
@@ -1219,18 +1219,18 @@ impl EngineWrapper for FastPortableWrapper {
         encode_pad: bool,
         decode_pad_mode: DecodePaddingMode,
     ) -> Self::Engine {
-        fast_portable::FastPortable::from(
+        general_purpose::GeneralPurpose::from(
             &STANDARD,
-            fast_portable::FastPortableConfig::new()
+            general_purpose::GeneralPurposeConfig::new()
                 .with_encode_padding(encode_pad)
                 .with_decode_padding_mode(decode_pad_mode),
         )
     }
 
     fn standard_allow_trailing_bits() -> Self::Engine {
-        fast_portable::FastPortable::from(
+        general_purpose::GeneralPurpose::from(
             &STANDARD,
-            fast_portable::FastPortableConfig::new().with_decode_allow_trailing_bits(true),
+            general_purpose::GeneralPurposeConfig::new().with_decode_allow_trailing_bits(true),
         )
     }
 
@@ -1241,7 +1241,7 @@ impl EngineWrapper for FastPortableWrapper {
     }
 
     fn random_alphabet<R: rand::Rng>(rng: &mut R, alphabet: &Alphabet) -> Self::Engine {
-        fast_portable::FastPortable::from(alphabet, random_config(rng))
+        general_purpose::GeneralPurpose::from(alphabet, random_config(rng))
     }
 }
 

--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -1205,11 +1205,11 @@ impl EngineWrapper for GeneralPurposeWrapper {
     type Engine = general_purpose::GeneralPurpose;
 
     fn standard() -> Self::Engine {
-        general_purpose::GeneralPurpose::from(&STANDARD, general_purpose::PAD)
+        general_purpose::GeneralPurpose::new(&STANDARD, general_purpose::PAD)
     }
 
     fn standard_unpadded() -> Self::Engine {
-        general_purpose::GeneralPurpose::from(
+        general_purpose::GeneralPurpose::new(
             &STANDARD,
             general_purpose::NO_PAD.with_decode_padding_mode(DecodePaddingMode::RequireNone),
         )
@@ -1219,7 +1219,7 @@ impl EngineWrapper for GeneralPurposeWrapper {
         encode_pad: bool,
         decode_pad_mode: DecodePaddingMode,
     ) -> Self::Engine {
-        general_purpose::GeneralPurpose::from(
+        general_purpose::GeneralPurpose::new(
             &STANDARD,
             general_purpose::GeneralPurposeConfig::new()
                 .with_encode_padding(encode_pad)
@@ -1228,7 +1228,7 @@ impl EngineWrapper for GeneralPurposeWrapper {
     }
 
     fn standard_allow_trailing_bits() -> Self::Engine {
-        general_purpose::GeneralPurpose::from(
+        general_purpose::GeneralPurpose::new(
             &STANDARD,
             general_purpose::GeneralPurposeConfig::new().with_decode_allow_trailing_bits(true),
         )
@@ -1241,7 +1241,7 @@ impl EngineWrapper for GeneralPurposeWrapper {
     }
 
     fn random_alphabet<R: rand::Rng>(rng: &mut R, alphabet: &Alphabet) -> Self::Engine {
-        general_purpose::GeneralPurpose::from(alphabet, random_config(rng))
+        general_purpose::GeneralPurpose::new(alphabet, random_config(rng))
     }
 }
 
@@ -1251,7 +1251,7 @@ impl EngineWrapper for NaiveWrapper {
     type Engine = naive::Naive;
 
     fn standard() -> Self::Engine {
-        naive::Naive::from(
+        naive::Naive::new(
             &STANDARD,
             naive::NaiveConfig {
                 encode_padding: true,
@@ -1262,7 +1262,7 @@ impl EngineWrapper for NaiveWrapper {
     }
 
     fn standard_unpadded() -> Self::Engine {
-        naive::Naive::from(
+        naive::Naive::new(
             &STANDARD,
             naive::NaiveConfig {
                 encode_padding: false,
@@ -1276,7 +1276,7 @@ impl EngineWrapper for NaiveWrapper {
         encode_pad: bool,
         decode_pad_mode: DecodePaddingMode,
     ) -> Self::Engine {
-        naive::Naive::from(
+        naive::Naive::new(
             &STANDARD,
             naive::NaiveConfig {
                 encode_padding: false,
@@ -1287,7 +1287,7 @@ impl EngineWrapper for NaiveWrapper {
     }
 
     fn standard_allow_trailing_bits() -> Self::Engine {
-        naive::Naive::from(
+        naive::Naive::new(
             &STANDARD,
             naive::NaiveConfig {
                 encode_padding: true,
@@ -1316,7 +1316,7 @@ impl EngineWrapper for NaiveWrapper {
             decode_padding_mode: mode,
         };
 
-        naive::Naive::from(alphabet, config)
+        naive::Naive::new(alphabet, config)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,12 +108,15 @@ pub mod read;
 pub mod write;
 
 pub mod engine;
+pub use engine::Engine;
 
 pub mod alphabet;
 
 mod encode;
+#[allow(deprecated)]
 #[cfg(any(feature = "alloc", feature = "std", test))]
 pub use crate::encode::{encode, encode_engine, encode_engine_string};
+#[allow(deprecated)]
 pub use crate::encode::{encode_engine_slice, encoded_len};
 
 mod decode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! Once you have an `Alphabet`, you can pick which `Engine` you want. A few parts of the public
 //! API provide a default, but otherwise the user must provide an `Engine` to use.
 //!
-//! See [engine::Engine] for more on what engine to choose, or use [engine::DEFAULT_ENGINE] if you
+//! See [engine::Engine] for more on what engine to choose, or use [engine::STANDARD] if you
 //! just want plain old standard base64 and don't have other requirements.
 //!
 //! ## Config

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,11 @@
 //! # Getting started
 //!
-//! tl;dr:
-//!
-//! 1. Perhaps one of the already available consts will suit:
-//!     - [engine::STANDARD]
-//!     - [engine::STANDARD_NO_PAD]
-//!     - [engine::URL_SAFE]
-//!     - [engine::URL_SAFE_NO_PAD]
+//! 1. Perhaps one of the preconfigured engines in [engine::general_purpose] will suit, e.g.
+//! [engine::general_purpose::STANDARD_NO_PAD].
+//!     - These are re-exported in [prelude] with a `BASE64_` prefix for those who prefer to
+//!       `use ...::prelude::*` or equivalent, e.g. [prelude::BASE64_STANDARD_NO_PAD]
 //! 1. If not, choose which alphabet you want. Most usage will want [alphabet::STANDARD] or [alphabet::URL_SAFE].
-//! 1. Choose which [Engine] you want. For the moment there is only one: [engine::GeneralPurpose].
+//! 1. Choose which [Engine] implementation you want. For the moment there is only one: [engine::GeneralPurpose].
 //! 1. Configure the engine appropriately using the engine's `Config` type.
 //!     - This is where you'll select whether to add padding (when encoding) or expect it (when
 //!     decoding). If given the choice, prefer no padding.
@@ -28,7 +25,7 @@
 //! Once you have an `Alphabet`, you can pick which `Engine` you want. A few parts of the public
 //! API provide a default, but otherwise the user must provide an `Engine` to use.
 //!
-//! See [engine::Engine] for more.
+//! See [Engine] for more.
 //!
 //! ## Config
 //!
@@ -85,15 +82,15 @@
 //! ## Using predefined engines
 //!
 //! ```
-//! use base64::{engine, Engine as _};
+//! use base64::{Engine as _, engine::general_purpose};
 //!
 //! let orig = b"data";
-//! let encoded: String = engine::STANDARD_NO_PAD.encode(orig);
+//! let encoded: String = general_purpose::STANDARD_NO_PAD.encode(orig);
 //! assert_eq!("ZGF0YQ", encoded);
-//! assert_eq!(orig.as_slice(), &engine::STANDARD_NO_PAD.decode(encoded).unwrap());
+//! assert_eq!(orig.as_slice(), &general_purpose::STANDARD_NO_PAD.decode(encoded).unwrap());
 //!
 //! // or, URL-safe
-//! let encoded_url = engine::URL_SAFE_NO_PAD.encode(orig);
+//! let encoded_url = general_purpose::URL_SAFE_NO_PAD.encode(orig);
 //! ```
 //!
 //! ## Custom alphabet, config, and engine
@@ -107,14 +104,14 @@
 //!     .unwrap();
 //!
 //! // a very weird config that encodes with padding but requires no padding when decoding...?
-//! let config = engine::GeneralPurposeConfig::new()
+//! let crazy_config = engine::GeneralPurposeConfig::new()
 //!     .with_decode_allow_trailing_bits(true)
 //!     .with_encode_padding(true)
 //!     .with_decode_padding_mode(engine::DecodePaddingMode::RequireNone);
 //!
-//! let engine = engine::GeneralPurpose::new(&alphabet, config);
+//! let crazy_engine = engine::GeneralPurpose::new(&alphabet, crazy_config);
 //!
-//! let encoded = engine.encode(b"abc 123");
+//! let encoded = crazy_engine.encode(b"abc 123");
 //!
 //! ```
 //!
@@ -173,6 +170,8 @@ mod decode;
 pub use crate::decode::{decode, decode_engine, decode_engine_vec};
 #[allow(deprecated)]
 pub use crate::decode::{decode_engine_slice, decoded_len_estimate, DecodeError, DecodeSliceError};
+
+pub mod prelude;
 
 #[cfg(test)]
 mod tests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,34 @@
-//! # Alphabets
+//! # Getting started
+//!
+//! tl;dr:
+//!
+//! 1. Perhaps one of the already available consts will suit:
+//!     - [engine::STANDARD]
+//!     - [engine::STANDARD_NO_PAD]
+//!     - [engine::URL_SAFE]
+//!     - [engine::URL_SAFE_NO_PAD]
+//! 1. If not, choose which alphabet you want. Most usage will want [alphabet::STANDARD] or [alphabet::URL_SAFE].
+//! 1. Choose which [Engine] you want. For the moment there is only one: [engine::GeneralPurpose].
+//! 1. Configure the engine appropriately using the engine's `Config` type.
+//!     - This is where you'll select whether to add padding (when encoding) or expect it (when
+//!     decoding). If given the choice, prefer no padding.
+//! 1. Build the engine using the selected alphabet and config.
+//!
+//! For more detail, see below.
+//!
+//! ## Alphabets
 //!
 //! An [alphabet::Alphabet] defines what ASCII symbols are used to encode to or decode from.
 //!
 //! Constants in [alphabet] like [alphabet::STANDARD] or [alphabet::URL_SAFE] provide commonly used
-//! alphabets, but you can also build your own custom `Alphabet` if needed.
+//! alphabets, but you can also build your own custom [alphabet::Alphabet] if needed.
 //!
-//! # Engines
+//! ## Engines
 //!
 //! Once you have an `Alphabet`, you can pick which `Engine` you want. A few parts of the public
 //! API provide a default, but otherwise the user must provide an `Engine` to use.
 //!
-//! See [engine::Engine] for more on what engine to choose, or use [engine::STANDARD] if you
-//! just want plain old standard base64 and don't have other requirements. [engine::URL_SAFE] and
-//! [engine::URL_SAFE_NO_PAD] are also available.
+//! See [engine::Engine] for more.
 //!
 //! ## Config
 //!
@@ -20,19 +36,16 @@
 //! `Engine` has a corresponding `Config` implementation since different `Engine`s may offer different
 //! levels of configurability.
 //!
-//! [encode()] and [decode()] use the standard alphabet and default engine in an RFC 4648 standard
-//! setup.
-//!
 //! # Encoding
 //!
 //! Several different encoding methods on [Engine] are available to you depending on your desire for
 //! convenience vs performance.
 //!
-//! | Method           | Output                       | Allocates                      |
-//! | ---------------- | ---------------------------- | ------------------------------ |
-//! | `encode`         | Returns a new `String`       | Always                         |
-//! | `encode_string`  | Appends to provided `String` | Only if `String` needs to grow |
-//! | `encode_slice`   | Writes to provided `&[u8]`   | Never - fastest                |
+//! | Method                   | Output                       | Allocates                      |
+//! | ------------------------ | ---------------------------- | ------------------------------ |
+//! | [Engine::encode]         | Returns a new `String`       | Always                         |
+//! | [Engine::encode_string]  | Appends to provided `String` | Only if `String` needs to grow |
+//! | [Engine::encode_slice]   | Writes to provided `&[u8]`   | Never - fastest                |
 //!
 //! All of the encoding methods will pad as per the engine's config.
 //!
@@ -40,11 +53,11 @@
 //!
 //! Just as for encoding, there are different decoding methods available.
 //!
-//! | Method           | Output                        | Allocates                      |
-//! | ---------------- | ----------------------------- | ------------------------------ |
-//! | `decode`         | Returns a new `Vec<u8>`       | Always                         |
-//! | `decode_vec`     | Appends to provided `Vec<u8>` | Only if `Vec` needs to grow    |
-//! | `decode_slice`   | Writes to provided `&[u8]`    | Never - fastest                |
+//! | Method                   | Output                        | Allocates                      |
+//! | ------------------------ | ----------------------------- | ------------------------------ |
+//! | [Engine::decode]         | Returns a new `Vec<u8>`       | Always                         |
+//! | [Engine::decode_vec]     | Appends to provided `Vec<u8>` | Only if `Vec` needs to grow    |
+//! | [Engine::decode_slice]   | Writes to provided `&[u8]`    | Never - fastest                |
 //!
 //! Unlike encoding, where all possible input is valid, decoding can fail (see [DecodeError]).
 //!
@@ -74,9 +87,10 @@
 //! ```
 //! use base64::{engine, Engine as _};
 //!
-//! let orig = b"some data";
-//! let encoded: String = engine::STANDARD.encode(orig);
-//! assert_eq!(orig.as_slice(), &engine::STANDARD.decode(encoded).unwrap());
+//! let orig = b"data";
+//! let encoded: String = engine::STANDARD_NO_PAD.encode(orig);
+//! assert_eq!("ZGF0YQ", encoded);
+//! assert_eq!(orig.as_slice(), &engine::STANDARD_NO_PAD.decode(encoded).unwrap());
 //!
 //! // or, URL-safe
 //! let encoded_url = engine::URL_SAFE_NO_PAD.encode(orig);
@@ -107,8 +121,6 @@
 //! # Panics
 //!
 //! If length calculations result in overflowing `usize`, a panic will result.
-//!
-//! The `_slice` flavors of encode or decode will panic if the provided output slice is too small.
 
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::cast_lossless))]
 #![deny(
@@ -153,14 +165,14 @@ mod encode;
 #[cfg(any(feature = "alloc", feature = "std", test))]
 pub use crate::encode::{encode, encode_engine, encode_engine_string};
 #[allow(deprecated)]
-pub use crate::encode::{encode_engine_slice, encoded_len};
+pub use crate::encode::{encode_engine_slice, encoded_len, EncodeSliceError};
 
 mod decode;
 #[allow(deprecated)]
 #[cfg(any(feature = "alloc", feature = "std", test))]
 pub use crate::decode::{decode, decode_engine, decode_engine_vec};
 #[allow(deprecated)]
-pub use crate::decode::{decode_engine_slice, DecodeError};
+pub use crate::decode::{decode_engine_slice, decoded_len_estimate, DecodeError, DecodeSliceError};
 
 #[cfg(test)]
 mod tests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! 1. Perhaps one of the preconfigured engines in [engine::general_purpose] will suit, e.g.
 //! [engine::general_purpose::STANDARD_NO_PAD].
 //!     - These are re-exported in [prelude] with a `BASE64_` prefix for those who prefer to
-//!       `use ...::prelude::*` or equivalent, e.g. [prelude::BASE64_STANDARD_NO_PAD]
+//!       `use base64::prelude::*` or equivalent, e.g. [prelude::BASE64_STANDARD_NO_PAD]
 //! 1. If not, choose which alphabet you want. Most usage will want [alphabet::STANDARD] or [alphabet::URL_SAFE].
 //! 1. Choose which [Engine] implementation you want. For the moment there is only one: [engine::GeneralPurpose].
 //! 1. Configure the engine appropriately using the engine's `Config` type.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,8 +120,10 @@ pub use crate::encode::{encode, encode_engine, encode_engine_string};
 pub use crate::encode::{encode_engine_slice, encoded_len};
 
 mod decode;
+#[allow(deprecated)]
 #[cfg(any(feature = "alloc", feature = "std", test))]
 pub use crate::decode::{decode, decode_engine, decode_engine_vec};
+#[allow(deprecated)]
 pub use crate::decode::{decode_engine_slice, DecodeError};
 
 #[cfg(test)]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -6,10 +6,13 @@
 //! # Examples
 //!
 //! ```
-//! use base64::{Engine as _, prelude::BASE64_STANDARD_NO_PAD};
+//! use base64::prelude::{Engine as _, BASE64_STANDARD_NO_PAD};
 //!
 //! assert_eq!("c29tZSBieXRlcw", &BASE64_STANDARD_NO_PAD.encode(b"some bytes"));
 //! ```
+
+pub use crate::engine::Engine;
+
 pub use crate::engine::general_purpose::STANDARD as BASE64_STANDARD;
 pub use crate::engine::general_purpose::STANDARD_NO_PAD as BASE64_STANDARD_NO_PAD;
 pub use crate::engine::general_purpose::URL_SAFE as BASE64_URL_SAFE;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,16 @@
+//! Preconfigured engines for common use cases.
+//!
+//! These are re-exports of `const` engines in [crate::engine::general_purpose], renamed with a `BASE64_`
+//! prefix for those who prefer to `use` the entire path to a name.
+//!
+//! # Examples
+//!
+//! ```
+//! use base64::{Engine as _, prelude::BASE64_STANDARD_NO_PAD};
+//!
+//! assert_eq!("c29tZSBieXRlcw", &BASE64_STANDARD_NO_PAD.encode(b"some bytes"));
+//! ```
+pub use crate::engine::general_purpose::STANDARD as BASE64_STANDARD;
+pub use crate::engine::general_purpose::STANDARD_NO_PAD as BASE64_STANDARD_NO_PAD;
+pub use crate::engine::general_purpose::URL_SAFE as BASE64_URL_SAFE;
+pub use crate::engine::general_purpose::URL_SAFE_NO_PAD as BASE64_URL_SAFE_NO_PAD;

--- a/src/read/decoder.rs
+++ b/src/read/decoder.rs
@@ -20,7 +20,7 @@ const DECODED_CHUNK_SIZE: usize = 3;
 /// let mut wrapped_reader = Cursor::new(b"YXNkZg==");
 /// let mut decoder = base64::read::DecoderReader::new(
 ///     &mut wrapped_reader,
-///     &base64::engine::DEFAULT_ENGINE);
+///     &base64::engine::STANDARD);
 ///
 /// // handle errors as you normally would
 /// let mut result = Vec::new();

--- a/src/read/decoder.rs
+++ b/src/read/decoder.rs
@@ -18,7 +18,7 @@ const DECODED_CHUNK_SIZE: usize = 3;
 ///
 /// // use a cursor as the simplest possible `Read` -- in real code this is probably a file, etc.
 /// let mut wrapped_reader = Cursor::new(b"YXNkZg==");
-/// let mut decoder = base64::read::DecoderReader::from(
+/// let mut decoder = base64::read::DecoderReader::new(
 ///     &mut wrapped_reader,
 ///     &base64::engine::DEFAULT_ENGINE);
 ///
@@ -69,7 +69,7 @@ impl<'e, E: Engine, R: io::Read> fmt::Debug for DecoderReader<'e, E, R> {
 
 impl<'e, E: Engine, R: io::Read> DecoderReader<'e, E, R> {
     /// Create a new decoder that will read from the provided reader `r`.
-    pub fn from(reader: R, engine: &'e E) -> Self {
+    pub fn new(reader: R, engine: &'e E) -> Self {
         DecoderReader {
             engine,
             inner: reader,

--- a/src/read/decoder.rs
+++ b/src/read/decoder.rs
@@ -15,12 +15,13 @@ const DECODED_CHUNK_SIZE: usize = 3;
 /// ```
 /// use std::io::Read;
 /// use std::io::Cursor;
+/// use base64::engine::general_purpose;
 ///
 /// // use a cursor as the simplest possible `Read` -- in real code this is probably a file, etc.
 /// let mut wrapped_reader = Cursor::new(b"YXNkZg==");
 /// let mut decoder = base64::read::DecoderReader::new(
 ///     &mut wrapped_reader,
-///     &base64::engine::STANDARD);
+///     &general_purpose::STANDARD);
 ///
 /// // handle errors as you normally would
 /// let mut result = Vec::new();

--- a/src/read/decoder.rs
+++ b/src/read/decoder.rs
@@ -133,9 +133,10 @@ impl<'e, E: Engine, R: io::Read> DecoderReader<'e, E, R> {
 
         let decoded = self
             .engine
-            .decode_slice(
+            .internal_decode(
                 &self.b64_buffer[self.b64_offset..self.b64_offset + num_bytes],
                 buf,
+                self.engine.internal_decoded_len_estimate(num_bytes),
             )
             .map_err(|e| match e {
                 DecodeError::InvalidByte(offset, byte) => {

--- a/src/read/decoder_tests.rs
+++ b/src/read/decoder_tests.rs
@@ -1,7 +1,10 @@
-use std::io::{self, Read};
+use std::{
+    cmp,
+    io::{self, Read as _},
+    iter,
+};
 
-use rand::{Rng, RngCore};
-use std::{cmp, iter};
+use rand::{Rng as _, RngCore as _};
 
 use super::decoder::{DecoderReader, BUF_SIZE};
 use crate::{
@@ -295,7 +298,7 @@ fn reports_invalid_byte_correctly() {
     }
 }
 
-fn consume_with_short_reads_and_validate<R: Read>(
+fn consume_with_short_reads_and_validate<R: io::Read>(
     rng: &mut rand::rngs::ThreadRng,
     expected_bytes: &[u8],
     decoded: &mut [u8],

--- a/src/read/decoder_tests.rs
+++ b/src/read/decoder_tests.rs
@@ -8,7 +8,7 @@ use rand::{Rng as _, RngCore as _};
 
 use super::decoder::{DecoderReader, BUF_SIZE};
 use crate::{
-    engine::{Engine, GeneralPurpose, DEFAULT_ENGINE},
+    engine::{Engine, GeneralPurpose, STANDARD},
     tests::{random_alphabet, random_config, random_engine},
     DecodeError,
 };
@@ -32,7 +32,7 @@ fn simple() {
         // Read n bytes at a time.
         for n in 1..base64data.len() + 1 {
             let mut wrapped_reader = io::Cursor::new(base64data);
-            let mut decoder = DecoderReader::new(&mut wrapped_reader, &DEFAULT_ENGINE);
+            let mut decoder = DecoderReader::new(&mut wrapped_reader, &STANDARD);
 
             // handle errors as you normally would
             let mut text_got = Vec::new();
@@ -64,7 +64,7 @@ fn trailing_junk() {
         // Read n bytes at a time.
         for n in 1..base64data.len() + 1 {
             let mut wrapped_reader = io::Cursor::new(base64data);
-            let mut decoder = DecoderReader::new(&mut wrapped_reader, &DEFAULT_ENGINE);
+            let mut decoder = DecoderReader::new(&mut wrapped_reader, &STANDARD);
 
             // handle errors as you normally would
             let mut buffer = vec![0u8; n];

--- a/src/read/decoder_tests.rs
+++ b/src/read/decoder_tests.rs
@@ -8,7 +8,6 @@ use rand::{Rng as _, RngCore as _};
 
 use super::decoder::{DecoderReader, BUF_SIZE};
 use crate::{
-    decode_engine_vec,
     engine::{Engine, GeneralPurpose, DEFAULT_ENGINE},
     tests::{random_alphabet, random_config, random_engine},
     DecodeError,
@@ -228,7 +227,7 @@ fn reports_invalid_last_symbol_correctly() {
 
             // replace the last
             *b64_bytes.last_mut().unwrap() = s1;
-            let bulk_res = decode_engine_vec(&b64_bytes[..], &mut bulk_decoded, &engine);
+            let bulk_res = engine.decode_vec(&b64_bytes[..], &mut bulk_decoded);
 
             let mut wrapped_reader = io::Cursor::new(&b64_bytes[..]);
             let mut decoder = DecoderReader::new(&mut wrapped_reader, &engine);
@@ -285,7 +284,7 @@ fn reports_invalid_byte_correctly() {
             .and_then(|o| o);
 
         let mut bulk_buf = Vec::new();
-        let bulk_decode_err = decode_engine_vec(&b64_bytes[..], &mut bulk_buf, &engine).err();
+        let bulk_decode_err = engine.decode_vec(&b64_bytes[..], &mut bulk_buf).err();
 
         // it's tricky to predict where the invalid data's offset will be since if it's in the last
         // chunk it will be reported at the first padding location because it's treated as invalid

--- a/src/read/decoder_tests.rs
+++ b/src/read/decoder_tests.rs
@@ -4,11 +4,13 @@ use rand::{Rng, RngCore};
 use std::{cmp, iter};
 
 use super::decoder::{DecoderReader, BUF_SIZE};
-use crate::encode::encode_engine_string;
-use crate::engine::fast_portable::FastPortable;
-use crate::engine::DEFAULT_ENGINE;
-use crate::tests::{random_alphabet, random_config, random_engine};
-use crate::{decode_engine_vec, DecodeError};
+use crate::{
+    decode_engine_vec,
+    encode::encode_engine_string,
+    engine::{GeneralPurpose, DEFAULT_ENGINE},
+    tests::{random_alphabet, random_config, random_engine},
+    DecodeError,
+};
 
 #[test]
 fn simple() {
@@ -211,7 +213,7 @@ fn reports_invalid_last_symbol_correctly() {
         let config = random_config(&mut rng);
         let alphabet = random_alphabet(&mut rng);
         // changing padding will cause invalid padding errors when we twiddle the last byte
-        let engine = FastPortable::from(alphabet, config.with_encode_padding(false));
+        let engine = GeneralPurpose::from(alphabet, config.with_encode_padding(false));
         encode_engine_string(&bytes[..], &mut b64, &engine);
         b64_bytes.extend(b64.bytes());
         assert_eq!(b64_bytes.len(), b64.len());

--- a/src/read/decoder_tests.rs
+++ b/src/read/decoder_tests.rs
@@ -8,7 +8,7 @@ use rand::{Rng as _, RngCore as _};
 
 use super::decoder::{DecoderReader, BUF_SIZE};
 use crate::{
-    engine::{Engine, GeneralPurpose, STANDARD},
+    engine::{general_purpose::STANDARD, Engine, GeneralPurpose},
     tests::{random_alphabet, random_config, random_engine},
     DecodeError,
 };

--- a/src/read/decoder_tests.rs
+++ b/src/read/decoder_tests.rs
@@ -9,8 +9,7 @@ use rand::{Rng as _, RngCore as _};
 use super::decoder::{DecoderReader, BUF_SIZE};
 use crate::{
     decode_engine_vec,
-    encode::encode_engine_string,
-    engine::{GeneralPurpose, DEFAULT_ENGINE},
+    engine::{Engine, GeneralPurpose, DEFAULT_ENGINE},
     tests::{random_alphabet, random_config, random_engine},
     DecodeError,
 };
@@ -106,7 +105,7 @@ fn handles_short_read_from_delegate() {
         assert_eq!(size, bytes.len());
 
         let engine = random_engine(&mut rng);
-        encode_engine_string(&bytes[..], &mut b64, &engine);
+        engine.encode_string(&bytes[..], &mut b64);
 
         let mut wrapped_reader = io::Cursor::new(b64.as_bytes());
         let mut short_reader = RandomShortRead {
@@ -144,7 +143,7 @@ fn read_in_short_increments() {
 
         let engine = random_engine(&mut rng);
 
-        encode_engine_string(&bytes[..], &mut b64, &engine);
+        engine.encode_string(&bytes[..], &mut b64);
 
         let mut wrapped_reader = io::Cursor::new(&b64[..]);
         let mut decoder = DecoderReader::new(&mut wrapped_reader, &engine);
@@ -175,7 +174,7 @@ fn read_in_short_increments_with_short_delegate_reads() {
 
         let engine = random_engine(&mut rng);
 
-        encode_engine_string(&bytes[..], &mut b64, &engine);
+        engine.encode_string(&bytes[..], &mut b64);
 
         let mut base_reader = io::Cursor::new(&b64[..]);
         let mut decoder = DecoderReader::new(&mut base_reader, &engine);
@@ -217,7 +216,7 @@ fn reports_invalid_last_symbol_correctly() {
         let alphabet = random_alphabet(&mut rng);
         // changing padding will cause invalid padding errors when we twiddle the last byte
         let engine = GeneralPurpose::new(alphabet, config.with_encode_padding(false));
-        encode_engine_string(&bytes[..], &mut b64, &engine);
+        engine.encode_string(&bytes[..], &mut b64);
         b64_bytes.extend(b64.bytes());
         assert_eq!(b64_bytes.len(), b64.len());
 
@@ -263,7 +262,7 @@ fn reports_invalid_byte_correctly() {
 
         let engine = random_engine(&mut rng);
 
-        encode_engine_string(&bytes[..], &mut b64, &engine);
+        engine.encode_string(&bytes[..], &mut b64);
         // replace one byte, somewhere, with '*', which is invalid
         let bad_byte_pos = rng.gen_range(0..b64.len());
         let mut b64_bytes = b64.bytes().collect::<Vec<u8>>();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -8,7 +8,7 @@ use rand::{
 };
 
 use crate::{
-    alphabet, decode_engine,
+    alphabet,
     encode::encoded_len,
     engine::{
         general_purpose::{GeneralPurpose, GeneralPurposeConfig},
@@ -71,7 +71,7 @@ fn roundtrip_random_config(input_len_range: Uniform<usize>, iterations: u32) {
 
         assert_encode_sanity(&encoded_buf, engine.config().encode_padding(), input_len);
 
-        assert_eq!(input_buf, decode_engine(&encoded_buf, &engine).unwrap());
+        assert_eq!(input_buf, engine.decode(&encoded_buf).unwrap());
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -105,7 +105,7 @@ pub fn random_alphabet<R: Rng>(rng: &mut R) -> &'static alphabet::Alphabet {
 pub fn random_engine<R: Rng>(rng: &mut R) -> GeneralPurpose {
     let alphabet = random_alphabet(rng);
     let config = random_config(rng);
-    GeneralPurpose::from(alphabet, config)
+    GeneralPurpose::new(alphabet, config)
 }
 
 const ALPHABETS: &[alphabet::Alphabet] = &[

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -10,7 +10,6 @@ use rand::{
 use crate::{
     alphabet, decode_engine,
     encode::encoded_len,
-    encode_engine_string,
     engine::{
         general_purpose::{GeneralPurpose, GeneralPurposeConfig},
         Config, DecodePaddingMode, Engine,
@@ -68,7 +67,7 @@ fn roundtrip_random_config(input_len_range: Uniform<usize>, iterations: u32) {
             input_buf.push(rng.gen());
         }
 
-        encode_engine_string(&input_buf, &mut encoded_buf, &engine);
+        engine.encode_string(&input_buf, &mut encoded_buf);
 
         assert_encode_sanity(&encoded_buf, engine.config().encode_padding(), input_len);
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -12,7 +12,7 @@ use crate::{
     encode::encoded_len,
     encode_engine_string,
     engine::{
-        fast_portable::{FastPortable, FastPortableConfig},
+        general_purpose::{GeneralPurpose, GeneralPurposeConfig},
         Config, DecodePaddingMode, Engine,
     },
 };
@@ -76,9 +76,9 @@ fn roundtrip_random_config(input_len_range: Uniform<usize>, iterations: u32) {
     }
 }
 
-pub fn random_config<R: Rng>(rng: &mut R) -> FastPortableConfig {
+pub fn random_config<R: Rng>(rng: &mut R) -> GeneralPurposeConfig {
     let mode = rng.gen();
-    FastPortableConfig::new()
+    GeneralPurposeConfig::new()
         .with_encode_padding(match mode {
             DecodePaddingMode::Indifferent => rng.gen(),
             DecodePaddingMode::RequireCanonical => true,
@@ -102,10 +102,10 @@ pub fn random_alphabet<R: Rng>(rng: &mut R) -> &'static alphabet::Alphabet {
     ALPHABETS.choose(rng).unwrap()
 }
 
-pub fn random_engine<R: Rng>(rng: &mut R) -> FastPortable {
+pub fn random_engine<R: Rng>(rng: &mut R) -> GeneralPurpose {
     let alphabet = random_alphabet(rng);
     let config = random_config(rng);
-    FastPortable::from(alphabet, config)
+    GeneralPurpose::from(alphabet, config)
 }
 
 const ALPHABETS: &[alphabet::Alphabet] = &[

--- a/src/write/encoder.rs
+++ b/src/write/encoder.rs
@@ -22,11 +22,10 @@ const MIN_ENCODE_CHUNK_SIZE: usize = 3;
 ///
 /// ```
 /// use std::io::Write;
+/// use base64::engine::general_purpose;
 ///
 /// // use a vec as the simplest possible `Write` -- in real code this is probably a file, etc.
-/// let mut enc = base64::write::EncoderWriter::new(
-///     Vec::new(),
-///     &base64::engine::STANDARD);
+/// let mut enc = base64::write::EncoderWriter::new(Vec::new(), &general_purpose::STANDARD);
 ///
 /// // handle errors as you normally would
 /// enc.write_all(b"asdf").unwrap();

--- a/src/write/encoder.rs
+++ b/src/write/encoder.rs
@@ -25,7 +25,7 @@ const MIN_ENCODE_CHUNK_SIZE: usize = 3;
 /// use std::io::Write;
 ///
 /// // use a vec as the simplest possible `Write` -- in real code this is probably a file, etc.
-/// let mut enc = base64::write::EncoderWriter::from(
+/// let mut enc = base64::write::EncoderWriter::new(
 ///     Vec::new(),
 ///     &base64::engine::DEFAULT_ENGINE);
 ///
@@ -97,7 +97,7 @@ impl<'e, E: Engine, W: io::Write> fmt::Debug for EncoderWriter<'e, E, W> {
 
 impl<'e, E: Engine, W: io::Write> EncoderWriter<'e, E, W> {
     /// Create a new encoder that will write to the provided delegate writer.
-    pub fn from(delegate: W, engine: &'e E) -> EncoderWriter<'e, E, W> {
+    pub fn new(delegate: W, engine: &'e E) -> EncoderWriter<'e, E, W> {
         EncoderWriter {
             engine,
             delegate: Some(delegate),

--- a/src/write/encoder.rs
+++ b/src/write/encoder.rs
@@ -1,4 +1,3 @@
-use crate::encode_engine_slice;
 use crate::engine::Engine;
 use std::{
     cmp, fmt, io,
@@ -150,10 +149,9 @@ impl<'e, E: Engine, W: io::Write> EncoderWriter<'e, E, W> {
         self.write_all_encoded_output()?;
 
         if self.extra_input_occupied_len > 0 {
-            let encoded_len = encode_engine_slice(
+            let encoded_len = self.engine.encode_slice(
                 &self.extra_input[..self.extra_input_occupied_len],
                 &mut self.output[..],
-                self.engine,
             );
 
             self.output_occupied_len = encoded_len;
@@ -314,7 +312,7 @@ impl<'e, E: Engine, W: io::Write> io::Write for EncoderWriter<'e, E, W> {
                 self.extra_input[self.extra_input_occupied_len..MIN_ENCODE_CHUNK_SIZE]
                     .copy_from_slice(&input[0..extra_input_read_len]);
 
-                let len = self.engine.encode(
+                let len = self.engine.inner_encode(
                     &self.extra_input[0..MIN_ENCODE_CHUNK_SIZE],
                     &mut self.output[..],
                 );
@@ -362,7 +360,7 @@ impl<'e, E: Engine, W: io::Write> io::Write for EncoderWriter<'e, E, W> {
         debug_assert_eq!(0, max_input_len % MIN_ENCODE_CHUNK_SIZE);
         debug_assert_eq!(0, input_chunks_to_encode_len % MIN_ENCODE_CHUNK_SIZE);
 
-        encoded_size += self.engine.encode(
+        encoded_size += self.engine.inner_encode(
             &input[..(input_chunks_to_encode_len)],
             &mut self.output[encoded_size..],
         );

--- a/src/write/encoder.rs
+++ b/src/write/encoder.rs
@@ -26,7 +26,7 @@ const MIN_ENCODE_CHUNK_SIZE: usize = 3;
 /// // use a vec as the simplest possible `Write` -- in real code this is probably a file, etc.
 /// let mut enc = base64::write::EncoderWriter::new(
 ///     Vec::new(),
-///     &base64::engine::DEFAULT_ENGINE);
+///     &base64::engine::STANDARD);
 ///
 /// // handle errors as you normally would
 /// enc.write_all(b"asdf").unwrap();

--- a/src/write/encoder.rs
+++ b/src/write/encoder.rs
@@ -149,10 +149,13 @@ impl<'e, E: Engine, W: io::Write> EncoderWriter<'e, E, W> {
         self.write_all_encoded_output()?;
 
         if self.extra_input_occupied_len > 0 {
-            let encoded_len = self.engine.encode_slice(
-                &self.extra_input[..self.extra_input_occupied_len],
-                &mut self.output[..],
-            );
+            let encoded_len = self
+                .engine
+                .encode_slice(
+                    &self.extra_input[..self.extra_input_occupied_len],
+                    &mut self.output[..],
+                )
+                .expect("buffer is large enough");
 
             self.output_occupied_len = encoded_len;
 
@@ -312,7 +315,7 @@ impl<'e, E: Engine, W: io::Write> io::Write for EncoderWriter<'e, E, W> {
                 self.extra_input[self.extra_input_occupied_len..MIN_ENCODE_CHUNK_SIZE]
                     .copy_from_slice(&input[0..extra_input_read_len]);
 
-                let len = self.engine.inner_encode(
+                let len = self.engine.internal_encode(
                     &self.extra_input[0..MIN_ENCODE_CHUNK_SIZE],
                     &mut self.output[..],
                 );
@@ -360,7 +363,7 @@ impl<'e, E: Engine, W: io::Write> io::Write for EncoderWriter<'e, E, W> {
         debug_assert_eq!(0, max_input_len % MIN_ENCODE_CHUNK_SIZE);
         debug_assert_eq!(0, input_chunks_to_encode_len % MIN_ENCODE_CHUNK_SIZE);
 
-        encoded_size += self.engine.inner_encode(
+        encoded_size += self.engine.internal_encode(
             &input[..(input_chunks_to_encode_len)],
             &mut self.output[encoded_size..],
         );

--- a/src/write/encoder_string_writer.rs
+++ b/src/write/encoder_string_writer.rs
@@ -1,7 +1,6 @@
 use super::encoder::EncoderWriter;
 use crate::engine::Engine;
 use std::io;
-use std::io::Write;
 
 /// A `Write` implementation that base64-encodes data using the provided config and accumulates the
 /// resulting base64 utf8 `&str` in a [StrConsumer] implementation (typically `String`), which is
@@ -84,7 +83,7 @@ impl<'e, E: Engine> EncoderStringWriter<'e, E, String> {
     }
 }
 
-impl<'e, E: Engine, S: StrConsumer> Write for EncoderStringWriter<'e, E, S> {
+impl<'e, E: Engine, S: StrConsumer> io::Write for EncoderStringWriter<'e, E, S> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.encoder.write(buf)
     }

--- a/src/write/encoder_string_writer.rs
+++ b/src/write/encoder_string_writer.rs
@@ -139,9 +139,9 @@ impl<S: StrConsumer> io::Write for Utf8SingleCodeUnitWriter<S> {
 
 #[cfg(test)]
 mod tests {
-    use crate::encode_engine_string;
-    use crate::tests::random_engine;
-    use crate::write::encoder_string_writer::EncoderStringWriter;
+    use crate::{
+        engine::Engine, tests::random_engine, write::encoder_string_writer::EncoderStringWriter,
+    };
     use rand::Rng;
     use std::io::Write;
 
@@ -162,7 +162,7 @@ mod tests {
             }
 
             let engine = random_engine(&mut rng);
-            encode_engine_string(&orig_data, &mut normal_encoded, &engine);
+            engine.encode_string(&orig_data, &mut normal_encoded);
 
             let mut stream_encoder = EncoderStringWriter::new(&engine);
             // Write the first i bytes, then the rest

--- a/src/write/encoder_string_writer.rs
+++ b/src/write/encoder_string_writer.rs
@@ -12,9 +12,9 @@ use std::io;
 ///
 /// ```
 /// use std::io::Write;
+/// use base64::engine::general_purpose;
 ///
-/// let mut enc = base64::write::EncoderStringWriter::new(
-///     &base64::engine::STANDARD);
+/// let mut enc = base64::write::EncoderStringWriter::new(&general_purpose::STANDARD);
 ///
 /// enc.write_all(b"asdf").unwrap();
 ///
@@ -28,12 +28,13 @@ use std::io;
 ///
 /// ```
 /// use std::io::Write;
+/// use base64::engine::general_purpose;
 ///
 /// let mut buf = String::from("base64: ");
 ///
 /// let mut enc = base64::write::EncoderStringWriter::from_consumer(
 ///     &mut buf,
-///     &base64::engine::STANDARD);
+///     &general_purpose::STANDARD);
 ///
 /// enc.write_all(b"asdf").unwrap();
 ///

--- a/src/write/encoder_string_writer.rs
+++ b/src/write/encoder_string_writer.rs
@@ -13,7 +13,7 @@ use std::io;
 /// ```
 /// use std::io::Write;
 ///
-/// let mut enc = base64::write::EncoderStringWriter::from(
+/// let mut enc = base64::write::EncoderStringWriter::new(
 ///     &base64::engine::DEFAULT_ENGINE);
 ///
 /// enc.write_all(b"asdf").unwrap();
@@ -60,7 +60,7 @@ impl<'e, E: Engine, S: StrConsumer> EncoderStringWriter<'e, E, S> {
     /// Create a EncoderStringWriter that will append to the provided `StrConsumer`.
     pub fn from_consumer(str_consumer: S, engine: &'e E) -> Self {
         EncoderStringWriter {
-            encoder: EncoderWriter::from(Utf8SingleCodeUnitWriter { str_consumer }, engine),
+            encoder: EncoderWriter::new(Utf8SingleCodeUnitWriter { str_consumer }, engine),
         }
     }
 
@@ -78,7 +78,7 @@ impl<'e, E: Engine, S: StrConsumer> EncoderStringWriter<'e, E, S> {
 
 impl<'e, E: Engine> EncoderStringWriter<'e, E, String> {
     /// Create a EncoderStringWriter that will encode into a new `String` with the provided config.
-    pub fn from(engine: &'e E) -> Self {
+    pub fn new(engine: &'e E) -> Self {
         EncoderStringWriter::from_consumer(String::new(), engine)
     }
 }
@@ -164,7 +164,7 @@ mod tests {
             let engine = random_engine(&mut rng);
             encode_engine_string(&orig_data, &mut normal_encoded, &engine);
 
-            let mut stream_encoder = EncoderStringWriter::from(&engine);
+            let mut stream_encoder = EncoderStringWriter::new(&engine);
             // Write the first i bytes, then the rest
             stream_encoder.write_all(&orig_data[0..i]).unwrap();
             stream_encoder.write_all(&orig_data[i..]).unwrap();

--- a/src/write/encoder_string_writer.rs
+++ b/src/write/encoder_string_writer.rs
@@ -14,7 +14,7 @@ use std::io;
 /// use std::io::Write;
 ///
 /// let mut enc = base64::write::EncoderStringWriter::new(
-///     &base64::engine::DEFAULT_ENGINE);
+///     &base64::engine::STANDARD);
 ///
 /// enc.write_all(b"asdf").unwrap();
 ///
@@ -33,7 +33,7 @@ use std::io;
 ///
 /// let mut enc = base64::write::EncoderStringWriter::from_consumer(
 ///     &mut buf,
-///     &base64::engine::DEFAULT_ENGINE);
+///     &base64::engine::STANDARD);
 ///
 /// enc.write_all(b"asdf").unwrap();
 ///

--- a/src/write/encoder_tests.rs
+++ b/src/write/encoder_tests.rs
@@ -12,14 +12,14 @@ use crate::{
 
 use super::EncoderWriter;
 
-const URL_SAFE_ENGINE: GeneralPurpose = GeneralPurpose::from(&URL_SAFE, PAD);
-const NO_PAD_ENGINE: GeneralPurpose = GeneralPurpose::from(&STANDARD, NO_PAD);
+const URL_SAFE_ENGINE: GeneralPurpose = GeneralPurpose::new(&URL_SAFE, PAD);
+const NO_PAD_ENGINE: GeneralPurpose = GeneralPurpose::new(&STANDARD, NO_PAD);
 
 #[test]
 fn encode_three_bytes() {
     let mut c = Cursor::new(Vec::new());
     {
-        let mut enc = EncoderWriter::from(&mut c, &URL_SAFE_ENGINE);
+        let mut enc = EncoderWriter::new(&mut c, &URL_SAFE_ENGINE);
 
         let sz = enc.write(b"abc").unwrap();
         assert_eq!(sz, 3);
@@ -34,7 +34,7 @@ fn encode_three_bytes() {
 fn encode_nine_bytes_two_writes() {
     let mut c = Cursor::new(Vec::new());
     {
-        let mut enc = EncoderWriter::from(&mut c, &URL_SAFE_ENGINE);
+        let mut enc = EncoderWriter::new(&mut c, &URL_SAFE_ENGINE);
 
         let sz = enc.write(b"abcdef").unwrap();
         assert_eq!(sz, 6);
@@ -51,7 +51,7 @@ fn encode_nine_bytes_two_writes() {
 fn encode_one_then_two_bytes() {
     let mut c = Cursor::new(Vec::new());
     {
-        let mut enc = EncoderWriter::from(&mut c, &URL_SAFE_ENGINE);
+        let mut enc = EncoderWriter::new(&mut c, &URL_SAFE_ENGINE);
 
         let sz = enc.write(b"a").unwrap();
         assert_eq!(sz, 1);
@@ -68,7 +68,7 @@ fn encode_one_then_two_bytes() {
 fn encode_one_then_five_bytes() {
     let mut c = Cursor::new(Vec::new());
     {
-        let mut enc = EncoderWriter::from(&mut c, &URL_SAFE_ENGINE);
+        let mut enc = EncoderWriter::new(&mut c, &URL_SAFE_ENGINE);
 
         let sz = enc.write(b"a").unwrap();
         assert_eq!(sz, 1);
@@ -85,7 +85,7 @@ fn encode_one_then_five_bytes() {
 fn encode_1_2_3_bytes() {
     let mut c = Cursor::new(Vec::new());
     {
-        let mut enc = EncoderWriter::from(&mut c, &URL_SAFE_ENGINE);
+        let mut enc = EncoderWriter::new(&mut c, &URL_SAFE_ENGINE);
 
         let sz = enc.write(b"a").unwrap();
         assert_eq!(sz, 1);
@@ -104,7 +104,7 @@ fn encode_1_2_3_bytes() {
 fn encode_with_padding() {
     let mut c = Cursor::new(Vec::new());
     {
-        let mut enc = EncoderWriter::from(&mut c, &URL_SAFE_ENGINE);
+        let mut enc = EncoderWriter::new(&mut c, &URL_SAFE_ENGINE);
 
         enc.write_all(b"abcd").unwrap();
 
@@ -120,7 +120,7 @@ fn encode_with_padding() {
 fn encode_with_padding_multiple_writes() {
     let mut c = Cursor::new(Vec::new());
     {
-        let mut enc = EncoderWriter::from(&mut c, &URL_SAFE_ENGINE);
+        let mut enc = EncoderWriter::new(&mut c, &URL_SAFE_ENGINE);
 
         assert_eq!(1, enc.write(b"a").unwrap());
         assert_eq!(2, enc.write(b"bc").unwrap());
@@ -139,7 +139,7 @@ fn encode_with_padding_multiple_writes() {
 fn finish_writes_extra_byte() {
     let mut c = Cursor::new(Vec::new());
     {
-        let mut enc = EncoderWriter::from(&mut c, &URL_SAFE_ENGINE);
+        let mut enc = EncoderWriter::new(&mut c, &URL_SAFE_ENGINE);
 
         assert_eq!(6, enc.write(b"abcdef").unwrap());
 
@@ -159,7 +159,7 @@ fn finish_writes_extra_byte() {
 fn write_partial_chunk_encodes_partial_chunk() {
     let mut c = Cursor::new(Vec::new());
     {
-        let mut enc = EncoderWriter::from(&mut c, &NO_PAD_ENGINE);
+        let mut enc = EncoderWriter::new(&mut c, &NO_PAD_ENGINE);
 
         // nothing encoded yet
         assert_eq!(2, enc.write(b"ab").unwrap());
@@ -177,7 +177,7 @@ fn write_partial_chunk_encodes_partial_chunk() {
 fn write_1_chunk_encodes_complete_chunk() {
     let mut c = Cursor::new(Vec::new());
     {
-        let mut enc = EncoderWriter::from(&mut c, &NO_PAD_ENGINE);
+        let mut enc = EncoderWriter::new(&mut c, &NO_PAD_ENGINE);
 
         assert_eq!(3, enc.write(b"abc").unwrap());
         let _ = enc.finish().unwrap();
@@ -193,7 +193,7 @@ fn write_1_chunk_encodes_complete_chunk() {
 fn write_1_chunk_and_partial_encodes_only_complete_chunk() {
     let mut c = Cursor::new(Vec::new());
     {
-        let mut enc = EncoderWriter::from(&mut c, &NO_PAD_ENGINE);
+        let mut enc = EncoderWriter::new(&mut c, &NO_PAD_ENGINE);
 
         // "d" not consumed since it's not a full chunk
         assert_eq!(3, enc.write(b"abcd").unwrap());
@@ -210,7 +210,7 @@ fn write_1_chunk_and_partial_encodes_only_complete_chunk() {
 fn write_2_partials_to_exactly_complete_chunk_encodes_complete_chunk() {
     let mut c = Cursor::new(Vec::new());
     {
-        let mut enc = EncoderWriter::from(&mut c, &NO_PAD_ENGINE);
+        let mut enc = EncoderWriter::new(&mut c, &NO_PAD_ENGINE);
 
         assert_eq!(1, enc.write(b"a").unwrap());
         assert_eq!(2, enc.write(b"bc").unwrap());
@@ -228,7 +228,7 @@ fn write_partial_then_enough_to_complete_chunk_but_not_complete_another_chunk_en
 ) {
     let mut c = Cursor::new(Vec::new());
     {
-        let mut enc = EncoderWriter::from(&mut c, &NO_PAD_ENGINE);
+        let mut enc = EncoderWriter::new(&mut c, &NO_PAD_ENGINE);
 
         assert_eq!(1, enc.write(b"a").unwrap());
         // doesn't consume "d"
@@ -246,7 +246,7 @@ fn write_partial_then_enough_to_complete_chunk_but_not_complete_another_chunk_en
 fn write_partial_then_enough_to_complete_chunk_and_another_chunk_encodes_complete_chunks() {
     let mut c = Cursor::new(Vec::new());
     {
-        let mut enc = EncoderWriter::from(&mut c, &NO_PAD_ENGINE);
+        let mut enc = EncoderWriter::new(&mut c, &NO_PAD_ENGINE);
 
         assert_eq!(1, enc.write(b"a").unwrap());
         // completes partial chunk, and another chunk
@@ -265,7 +265,7 @@ fn write_partial_then_enough_to_complete_chunk_and_another_chunk_and_another_par
 ) {
     let mut c = Cursor::new(Vec::new());
     {
-        let mut enc = EncoderWriter::from(&mut c, &NO_PAD_ENGINE);
+        let mut enc = EncoderWriter::new(&mut c, &NO_PAD_ENGINE);
 
         assert_eq!(1, enc.write(b"a").unwrap());
         // completes partial chunk, and another chunk, with one more partial chunk that's not
@@ -284,7 +284,7 @@ fn write_partial_then_enough_to_complete_chunk_and_another_chunk_and_another_par
 fn drop_calls_finish_for_you() {
     let mut c = Cursor::new(Vec::new());
     {
-        let mut enc = EncoderWriter::from(&mut c, &NO_PAD_ENGINE);
+        let mut enc = EncoderWriter::new(&mut c, &NO_PAD_ENGINE);
         assert_eq!(1, enc.write(b"a").unwrap());
     }
     assert_eq!(
@@ -316,7 +316,7 @@ fn every_possible_split_of_input() {
         encode_engine_string(&orig_data, &mut normal_encoded, &engine);
 
         {
-            let mut stream_encoder = EncoderWriter::from(&mut stream_encoded, &engine);
+            let mut stream_encoder = EncoderWriter::new(&mut stream_encoded, &engine);
             // Write the first i bytes, then the rest
             stream_encoder.write_all(&orig_data[0..i]).unwrap();
             stream_encoder.write_all(&orig_data[i..]).unwrap();
@@ -367,7 +367,7 @@ fn retrying_writes_that_error_with_interrupted_works() {
                 fraction: 0.8,
             };
 
-            let mut stream_encoder = EncoderWriter::from(&mut interrupting_writer, &engine);
+            let mut stream_encoder = EncoderWriter::new(&mut interrupting_writer, &engine);
             let mut bytes_consumed = 0;
             while bytes_consumed < orig_len {
                 // use short inputs since we want to use `extra` a lot as that's what needs rollback
@@ -432,7 +432,7 @@ fn writes_that_only_write_part_of_input_and_sometimes_interrupt_produce_correct_
                 no_interrupt_fraction: 0.1,
             };
 
-            let mut stream_encoder = EncoderWriter::from(&mut partial_writer, &engine);
+            let mut stream_encoder = EncoderWriter::new(&mut partial_writer, &engine);
             let mut bytes_consumed = 0;
             while bytes_consumed < orig_len {
                 // use at most medium-length inputs to exercise retry logic more aggressively
@@ -503,7 +503,7 @@ fn do_encode_random_config_matches_normal_encode(max_input_len: usize) {
 
         // encode via the stream encoder
         {
-            let mut stream_encoder = EncoderWriter::from(&mut stream_encoded, &engine);
+            let mut stream_encoder = EncoderWriter::new(&mut stream_encoded, &engine);
             let mut bytes_consumed = 0;
             while bytes_consumed < orig_len {
                 let input_len: usize =

--- a/src/write/encoder_tests.rs
+++ b/src/write/encoder_tests.rs
@@ -5,8 +5,10 @@ use rand::Rng;
 
 use crate::{
     alphabet::{STANDARD, URL_SAFE},
-    encode_engine, encode_engine_string,
-    engine::general_purpose::{GeneralPurpose, NO_PAD, PAD},
+    engine::{
+        general_purpose::{GeneralPurpose, NO_PAD, PAD},
+        Engine,
+    },
     tests::random_engine,
 };
 
@@ -24,10 +26,7 @@ fn encode_three_bytes() {
         let sz = enc.write(b"abc").unwrap();
         assert_eq!(sz, 3);
     }
-    assert_eq!(
-        &c.get_ref()[..],
-        encode_engine("abc", &URL_SAFE_ENGINE).as_bytes()
-    );
+    assert_eq!(&c.get_ref()[..], URL_SAFE_ENGINE.encode("abc").as_bytes());
 }
 
 #[test]
@@ -43,7 +42,7 @@ fn encode_nine_bytes_two_writes() {
     }
     assert_eq!(
         &c.get_ref()[..],
-        encode_engine("abcdefghi", &URL_SAFE_ENGINE).as_bytes()
+        URL_SAFE_ENGINE.encode("abcdefghi").as_bytes()
     );
 }
 
@@ -58,10 +57,7 @@ fn encode_one_then_two_bytes() {
         let sz = enc.write(b"bc").unwrap();
         assert_eq!(sz, 2);
     }
-    assert_eq!(
-        &c.get_ref()[..],
-        encode_engine("abc", &URL_SAFE_ENGINE).as_bytes()
-    );
+    assert_eq!(&c.get_ref()[..], URL_SAFE_ENGINE.encode("abc").as_bytes());
 }
 
 #[test]
@@ -77,7 +73,7 @@ fn encode_one_then_five_bytes() {
     }
     assert_eq!(
         &c.get_ref()[..],
-        encode_engine("abcdef", &URL_SAFE_ENGINE).as_bytes()
+        URL_SAFE_ENGINE.encode("abcdef").as_bytes()
     );
 }
 
@@ -96,7 +92,7 @@ fn encode_1_2_3_bytes() {
     }
     assert_eq!(
         &c.get_ref()[..],
-        encode_engine("abcdef", &URL_SAFE_ENGINE).as_bytes()
+        URL_SAFE_ENGINE.encode("abcdef").as_bytes()
     );
 }
 
@@ -110,10 +106,7 @@ fn encode_with_padding() {
 
         enc.flush().unwrap();
     }
-    assert_eq!(
-        &c.get_ref()[..],
-        encode_engine("abcd", &URL_SAFE_ENGINE).as_bytes()
-    );
+    assert_eq!(&c.get_ref()[..], URL_SAFE_ENGINE.encode("abcd").as_bytes());
 }
 
 #[test]
@@ -131,7 +124,7 @@ fn encode_with_padding_multiple_writes() {
     }
     assert_eq!(
         &c.get_ref()[..],
-        encode_engine("abcdefg", &URL_SAFE_ENGINE).as_bytes()
+        URL_SAFE_ENGINE.encode("abcdefg").as_bytes()
     );
 }
 
@@ -151,7 +144,7 @@ fn finish_writes_extra_byte() {
     }
     assert_eq!(
         &c.get_ref()[..],
-        encode_engine("abcdefg", &URL_SAFE_ENGINE).as_bytes()
+        URL_SAFE_ENGINE.encode("abcdefg").as_bytes()
     );
 }
 
@@ -166,10 +159,7 @@ fn write_partial_chunk_encodes_partial_chunk() {
         // encoded here
         let _ = enc.finish().unwrap();
     }
-    assert_eq!(
-        &c.get_ref()[..],
-        encode_engine("ab", &NO_PAD_ENGINE).as_bytes()
-    );
+    assert_eq!(&c.get_ref()[..], NO_PAD_ENGINE.encode("ab").as_bytes());
     assert_eq!(3, c.get_ref().len());
 }
 
@@ -182,10 +172,7 @@ fn write_1_chunk_encodes_complete_chunk() {
         assert_eq!(3, enc.write(b"abc").unwrap());
         let _ = enc.finish().unwrap();
     }
-    assert_eq!(
-        &c.get_ref()[..],
-        encode_engine("abc", &NO_PAD_ENGINE).as_bytes()
-    );
+    assert_eq!(&c.get_ref()[..], NO_PAD_ENGINE.encode("abc").as_bytes());
     assert_eq!(4, c.get_ref().len());
 }
 
@@ -199,10 +186,7 @@ fn write_1_chunk_and_partial_encodes_only_complete_chunk() {
         assert_eq!(3, enc.write(b"abcd").unwrap());
         let _ = enc.finish().unwrap();
     }
-    assert_eq!(
-        &c.get_ref()[..],
-        encode_engine("abc", &NO_PAD_ENGINE).as_bytes()
-    );
+    assert_eq!(&c.get_ref()[..], NO_PAD_ENGINE.encode("abc").as_bytes());
     assert_eq!(4, c.get_ref().len());
 }
 
@@ -216,10 +200,7 @@ fn write_2_partials_to_exactly_complete_chunk_encodes_complete_chunk() {
         assert_eq!(2, enc.write(b"bc").unwrap());
         let _ = enc.finish().unwrap();
     }
-    assert_eq!(
-        &c.get_ref()[..],
-        encode_engine("abc", &NO_PAD_ENGINE).as_bytes()
-    );
+    assert_eq!(&c.get_ref()[..], NO_PAD_ENGINE.encode("abc").as_bytes());
     assert_eq!(4, c.get_ref().len());
 }
 
@@ -235,10 +216,7 @@ fn write_partial_then_enough_to_complete_chunk_but_not_complete_another_chunk_en
         assert_eq!(2, enc.write(b"bcd").unwrap());
         let _ = enc.finish().unwrap();
     }
-    assert_eq!(
-        &c.get_ref()[..],
-        encode_engine("abc", &NO_PAD_ENGINE).as_bytes()
-    );
+    assert_eq!(&c.get_ref()[..], NO_PAD_ENGINE.encode("abc").as_bytes());
     assert_eq!(4, c.get_ref().len());
 }
 
@@ -253,10 +231,7 @@ fn write_partial_then_enough_to_complete_chunk_and_another_chunk_encodes_complet
         assert_eq!(5, enc.write(b"bcdef").unwrap());
         let _ = enc.finish().unwrap();
     }
-    assert_eq!(
-        &c.get_ref()[..],
-        encode_engine("abcdef", &NO_PAD_ENGINE).as_bytes()
-    );
+    assert_eq!(&c.get_ref()[..], NO_PAD_ENGINE.encode("abcdef").as_bytes());
     assert_eq!(8, c.get_ref().len());
 }
 
@@ -273,10 +248,7 @@ fn write_partial_then_enough_to_complete_chunk_and_another_chunk_and_another_par
         assert_eq!(5, enc.write(b"bcdefe").unwrap());
         let _ = enc.finish().unwrap();
     }
-    assert_eq!(
-        &c.get_ref()[..],
-        encode_engine("abcdef", &NO_PAD_ENGINE).as_bytes()
-    );
+    assert_eq!(&c.get_ref()[..], NO_PAD_ENGINE.encode("abcdef").as_bytes());
     assert_eq!(8, c.get_ref().len());
 }
 
@@ -287,10 +259,7 @@ fn drop_calls_finish_for_you() {
         let mut enc = EncoderWriter::new(&mut c, &NO_PAD_ENGINE);
         assert_eq!(1, enc.write(b"a").unwrap());
     }
-    assert_eq!(
-        &c.get_ref()[..],
-        encode_engine("a", &NO_PAD_ENGINE).as_bytes()
-    );
+    assert_eq!(&c.get_ref()[..], NO_PAD_ENGINE.encode("a").as_bytes());
     assert_eq!(2, c.get_ref().len());
 }
 
@@ -313,7 +282,7 @@ fn every_possible_split_of_input() {
         }
 
         let engine = random_engine(&mut rng);
-        encode_engine_string(&orig_data, &mut normal_encoded, &engine);
+        engine.encode_string(&orig_data, &mut normal_encoded);
 
         {
             let mut stream_encoder = EncoderWriter::new(&mut stream_encoded, &engine);
@@ -356,7 +325,7 @@ fn retrying_writes_that_error_with_interrupted_works() {
 
         // encode the normal way
         let engine = random_engine(&mut rng);
-        encode_engine_string(&orig_data, &mut normal_encoded, &engine);
+        engine.encode_string(&orig_data, &mut normal_encoded);
 
         // encode via the stream encoder
         {
@@ -420,7 +389,7 @@ fn writes_that_only_write_part_of_input_and_sometimes_interrupt_produce_correct_
 
         // encode the normal way
         let engine = random_engine(&mut rng);
-        encode_engine_string(&orig_data, &mut normal_encoded, &engine);
+        engine.encode_string(&orig_data, &mut normal_encoded);
 
         // encode via the stream encoder
         {
@@ -499,7 +468,7 @@ fn do_encode_random_config_matches_normal_encode(max_input_len: usize) {
 
         // encode the normal way
         let engine = random_engine(&mut rng);
-        encode_engine_string(&orig_data, &mut normal_encoded, &engine);
+        engine.encode_string(&orig_data, &mut normal_encoded);
 
         // encode via the stream encoder
         {

--- a/src/write/encoder_tests.rs
+++ b/src/write/encoder_tests.rs
@@ -3,15 +3,17 @@ use std::{cmp, io, str};
 
 use rand::Rng;
 
-use crate::alphabet::{STANDARD, URL_SAFE};
-use crate::engine::fast_portable::{FastPortable, NO_PAD, PAD};
-use crate::tests::random_engine;
-use crate::{encode_engine, encode_engine_string};
+use crate::{
+    alphabet::{STANDARD, URL_SAFE},
+    encode_engine, encode_engine_string,
+    engine::general_purpose::{GeneralPurpose, NO_PAD, PAD},
+    tests::random_engine,
+};
 
 use super::EncoderWriter;
 
-const URL_SAFE_ENGINE: FastPortable = FastPortable::from(&URL_SAFE, PAD);
-const NO_PAD_ENGINE: FastPortable = FastPortable::from(&STANDARD, NO_PAD);
+const URL_SAFE_ENGINE: GeneralPurpose = GeneralPurpose::from(&URL_SAFE, PAD);
+const NO_PAD_ENGINE: GeneralPurpose = GeneralPurpose::from(&STANDARD, NO_PAD);
 
 #[test]
 fn encode_three_bytes() {

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -1,9 +1,11 @@
 //! Implementations of `io::Write` to transparently handle base64.
 mod encoder;
 mod encoder_string_writer;
-pub use self::encoder::EncoderWriter;
-pub use self::encoder_string_writer::EncoderStringWriter;
-pub use self::encoder_string_writer::StrConsumer;
+
+pub use self::{
+    encoder::EncoderWriter,
+    encoder_string_writer::{EncoderStringWriter, StrConsumer},
+};
 
 #[cfg(test)]
 mod encoder_tests;

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -1,7 +1,7 @@
-use base64::{alphabet::URL_SAFE, engine::general_purpose::PAD, engine::DEFAULT_ENGINE, *};
+use base64::{alphabet::URL_SAFE, engine::general_purpose::PAD, engine::STANDARD, *};
 
 fn compare_encode(expected: &str, target: &[u8]) {
-    assert_eq!(expected, DEFAULT_ENGINE.encode(target));
+    assert_eq!(expected, STANDARD.encode(target));
 }
 
 #[test]

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -55,9 +55,6 @@ fn encode_all_bytes_url() {
          -AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq\
          -wsbKztLW2t7i5uru8vb6_wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t_g4eLj5OXm5-jp6uvs7e7v8PHy\
          8_T19vf4-fr7_P3-_w==",
-        encode_engine(
-            &bytes,
-            &engine::GeneralPurpose::from(&URL_SAFE, PAD),
-        )
+        encode_engine(&bytes, &engine::GeneralPurpose::new(&URL_SAFE, PAD),)
     );
 }

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -1,9 +1,7 @@
-use base64::alphabet::URL_SAFE;
-use base64::engine::general_purpose::PAD;
-use base64::*;
+use base64::{alphabet::URL_SAFE, engine::general_purpose::PAD, engine::DEFAULT_ENGINE, *};
 
 fn compare_encode(expected: &str, target: &[u8]) {
-    assert_eq!(expected, encode(target));
+    assert_eq!(expected, DEFAULT_ENGINE.encode(target));
 }
 
 #[test]
@@ -55,6 +53,6 @@ fn encode_all_bytes_url() {
          -AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq\
          -wsbKztLW2t7i5uru8vb6_wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t_g4eLj5OXm5-jp6uvs7e7v8PHy\
          8_T19vf4-fr7_P3-_w==",
-        encode_engine(&bytes, &engine::GeneralPurpose::new(&URL_SAFE, PAD),)
+        &engine::GeneralPurpose::new(&URL_SAFE, PAD).encode(&bytes)
     );
 }

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -1,4 +1,6 @@
-use base64::{alphabet::URL_SAFE, engine::general_purpose::PAD, engine::STANDARD, *};
+use base64::{
+    alphabet::URL_SAFE, engine::general_purpose::PAD, engine::general_purpose::STANDARD, *,
+};
 
 fn compare_encode(expected: &str, target: &[u8]) {
     assert_eq!(expected, STANDARD.encode(target));

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -1,5 +1,5 @@
 use base64::alphabet::URL_SAFE;
-use base64::engine::fast_portable::PAD;
+use base64::engine::general_purpose::PAD;
 use base64::*;
 
 fn compare_encode(expected: &str, target: &[u8]) {
@@ -57,7 +57,7 @@ fn encode_all_bytes_url() {
          8_T19vf4-fr7_P3-_w==",
         encode_engine(
             &bytes,
-            &engine::fast_portable::FastPortable::from(&URL_SAFE, PAD),
+            &engine::GeneralPurpose::from(&URL_SAFE, PAD),
         )
     );
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,9 +1,8 @@
 use rand::{Rng, SeedableRng};
 
-use base64::engine::{Engine, DEFAULT_ENGINE};
+use base64::engine::{Engine, STANDARD};
 use base64::*;
 
-use base64::alphabet::STANDARD;
 use base64::engine::general_purpose::{GeneralPurpose, NO_PAD};
 
 // generate random contents of the specified length and test encode/decode roundtrip
@@ -56,14 +55,7 @@ fn roundtrip_random_short_standard() {
     let mut str_buf = String::new();
 
     for input_len in 0..40 {
-        roundtrip_random(
-            &mut byte_buf,
-            &mut str_buf,
-            &DEFAULT_ENGINE,
-            input_len,
-            4,
-            10000,
-        );
+        roundtrip_random(&mut byte_buf, &mut str_buf, &STANDARD, input_len, 4, 10000);
     }
 }
 
@@ -73,14 +65,7 @@ fn roundtrip_random_with_fast_loop_standard() {
     let mut str_buf = String::new();
 
     for input_len in 40..100 {
-        roundtrip_random(
-            &mut byte_buf,
-            &mut str_buf,
-            &DEFAULT_ENGINE,
-            input_len,
-            4,
-            1000,
-        );
+        roundtrip_random(&mut byte_buf, &mut str_buf, &STANDARD, input_len, 4, 1000);
     }
 }
 
@@ -89,7 +74,7 @@ fn roundtrip_random_short_no_padding() {
     let mut byte_buf: Vec<u8> = Vec::new();
     let mut str_buf = String::new();
 
-    let engine = GeneralPurpose::new(&STANDARD, NO_PAD);
+    let engine = GeneralPurpose::new(&alphabet::STANDARD, NO_PAD);
     for input_len in 0..40 {
         roundtrip_random(&mut byte_buf, &mut str_buf, &engine, input_len, 4, 10000);
     }
@@ -100,7 +85,7 @@ fn roundtrip_random_no_padding() {
     let mut byte_buf: Vec<u8> = Vec::new();
     let mut str_buf = String::new();
 
-    let engine = GeneralPurpose::new(&STANDARD, NO_PAD);
+    let engine = GeneralPurpose::new(&alphabet::STANDARD, NO_PAD);
 
     for input_len in 40..100 {
         roundtrip_random(&mut byte_buf, &mut str_buf, &engine, input_len, 4, 1000);
@@ -120,7 +105,7 @@ fn roundtrip_decode_trailing_10_bytes() {
         let mut s: String = "ABCD".repeat(num_quads);
         s.push_str("EFGHIJKLZg");
 
-        let engine = GeneralPurpose::new(&STANDARD, NO_PAD);
+        let engine = GeneralPurpose::new(&alphabet::STANDARD, NO_PAD);
         let decoded = engine.decode(&s).unwrap();
         assert_eq!(num_quads * 3 + 7, decoded.len());
 
@@ -138,8 +123,8 @@ fn display_wrapper_matches_normal_encode() {
     bytes.push(255);
 
     assert_eq!(
-        DEFAULT_ENGINE.encode(&bytes),
-        format!("{}", display::Base64Display::new(&bytes, &DEFAULT_ENGINE))
+        STANDARD.encode(&bytes),
+        format!("{}", display::Base64Display::new(&bytes, &STANDARD))
     );
 }
 
@@ -154,5 +139,5 @@ fn encode_engine_slice_panics_when_buffer_too_small() {
         *elt = rng.gen();
     }
 
-    DEFAULT_ENGINE.encode_slice(input, &mut buf);
+    STANDARD.encode_slice(input, &mut buf);
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,7 +4,7 @@ use base64::engine::{Engine, DEFAULT_ENGINE};
 use base64::*;
 
 use base64::alphabet::STANDARD;
-use base64::engine::fast_portable::{FastPortable, NO_PAD};
+use base64::engine::general_purpose::{GeneralPurpose, NO_PAD};
 
 // generate random contents of the specified length and test encode/decode roundtrip
 fn roundtrip_random<E: Engine>(
@@ -89,7 +89,7 @@ fn roundtrip_random_short_no_padding() {
     let mut byte_buf: Vec<u8> = Vec::new();
     let mut str_buf = String::new();
 
-    let engine = FastPortable::from(&STANDARD, NO_PAD);
+    let engine = GeneralPurpose::from(&STANDARD, NO_PAD);
     for input_len in 0..40 {
         roundtrip_random(&mut byte_buf, &mut str_buf, &engine, input_len, 4, 10000);
     }
@@ -100,7 +100,7 @@ fn roundtrip_random_no_padding() {
     let mut byte_buf: Vec<u8> = Vec::new();
     let mut str_buf = String::new();
 
-    let engine = FastPortable::from(&STANDARD, NO_PAD);
+    let engine = GeneralPurpose::from(&STANDARD, NO_PAD);
 
     for input_len in 40..100 {
         roundtrip_random(&mut byte_buf, &mut str_buf, &engine, input_len, 4, 1000);
@@ -120,7 +120,7 @@ fn roundtrip_decode_trailing_10_bytes() {
         let mut s: String = "ABCD".repeat(num_quads);
         s.push_str("EFGHIJKLZg");
 
-        let engine = FastPortable::from(&STANDARD, NO_PAD);
+        let engine = GeneralPurpose::from(&STANDARD, NO_PAD);
         let decoded = decode_engine(&s, &engine).unwrap();
         assert_eq!(num_quads * 3 + 7, decoded.len());
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -129,15 +129,33 @@ fn display_wrapper_matches_normal_encode() {
 }
 
 #[test]
-#[should_panic(expected = "index 24 out of range for slice of length 22")]
-fn encode_engine_slice_panics_when_buffer_too_small() {
-    let mut buf: [u8; 22] = [0; 22];
-    let mut input: [u8; 16] = [0; 16];
-
-    let mut rng = rand::rngs::SmallRng::from_entropy();
-    for elt in &mut input {
-        *elt = rng.gen();
+fn encode_engine_slice_error_when_buffer_too_small() {
+    for num_triples in 1..100 {
+        let input = "AAA".repeat(num_triples);
+        let mut vec = vec![0; (num_triples - 1) * 4];
+        assert_eq!(
+            EncodeSliceError::OutputSliceTooSmall,
+            STANDARD.encode_slice(&input, &mut vec).unwrap_err()
+        );
+        vec.push(0);
+        assert_eq!(
+            EncodeSliceError::OutputSliceTooSmall,
+            STANDARD.encode_slice(&input, &mut vec).unwrap_err()
+        );
+        vec.push(0);
+        assert_eq!(
+            EncodeSliceError::OutputSliceTooSmall,
+            STANDARD.encode_slice(&input, &mut vec).unwrap_err()
+        );
+        vec.push(0);
+        assert_eq!(
+            EncodeSliceError::OutputSliceTooSmall,
+            STANDARD.encode_slice(&input, &mut vec).unwrap_err()
+        );
+        vec.push(0);
+        assert_eq!(
+            num_triples * 4,
+            STANDARD.encode_slice(&input, &mut vec).unwrap()
+        );
     }
-
-    STANDARD.encode_slice(input, &mut buf);
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -29,7 +29,7 @@ fn roundtrip_random<E: Engine>(
         }
 
         engine.encode_string(&byte_buf, str_buf);
-        decode_engine_vec(&str_buf, &mut decode_buf, engine).unwrap();
+        engine.decode_vec(&str_buf, &mut decode_buf).unwrap();
 
         assert_eq!(byte_buf, &decode_buf);
     }
@@ -121,7 +121,7 @@ fn roundtrip_decode_trailing_10_bytes() {
         s.push_str("EFGHIJKLZg");
 
         let engine = GeneralPurpose::new(&STANDARD, NO_PAD);
-        let decoded = decode_engine(&s, &engine).unwrap();
+        let decoded = engine.decode(&s).unwrap();
         assert_eq!(num_quads * 3 + 7, decoded.len());
 
         assert_eq!(s, engine.encode(&decoded));

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -28,7 +28,7 @@ fn roundtrip_random<E: Engine>(
             byte_buf.push(r.gen::<u8>());
         }
 
-        encode_engine_string(&byte_buf, str_buf, engine);
+        engine.encode_string(&byte_buf, str_buf);
         decode_engine_vec(&str_buf, &mut decode_buf, engine).unwrap();
 
         assert_eq!(byte_buf, &decode_buf);
@@ -124,7 +124,7 @@ fn roundtrip_decode_trailing_10_bytes() {
         let decoded = decode_engine(&s, &engine).unwrap();
         assert_eq!(num_quads * 3 + 7, decoded.len());
 
-        assert_eq!(s, encode_engine(&decoded, &engine));
+        assert_eq!(s, engine.encode(&decoded));
     }
 }
 
@@ -138,7 +138,7 @@ fn display_wrapper_matches_normal_encode() {
     bytes.push(255);
 
     assert_eq!(
-        encode(&bytes),
+        DEFAULT_ENGINE.encode(&bytes),
         format!("{}", display::Base64Display::new(&bytes, &DEFAULT_ENGINE))
     );
 }
@@ -154,5 +154,5 @@ fn encode_engine_slice_panics_when_buffer_too_small() {
         *elt = rng.gen();
     }
 
-    encode_engine_slice(input, &mut buf, &DEFAULT_ENGINE);
+    DEFAULT_ENGINE.encode_slice(input, &mut buf);
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -89,7 +89,7 @@ fn roundtrip_random_short_no_padding() {
     let mut byte_buf: Vec<u8> = Vec::new();
     let mut str_buf = String::new();
 
-    let engine = GeneralPurpose::from(&STANDARD, NO_PAD);
+    let engine = GeneralPurpose::new(&STANDARD, NO_PAD);
     for input_len in 0..40 {
         roundtrip_random(&mut byte_buf, &mut str_buf, &engine, input_len, 4, 10000);
     }
@@ -100,7 +100,7 @@ fn roundtrip_random_no_padding() {
     let mut byte_buf: Vec<u8> = Vec::new();
     let mut str_buf = String::new();
 
-    let engine = GeneralPurpose::from(&STANDARD, NO_PAD);
+    let engine = GeneralPurpose::new(&STANDARD, NO_PAD);
 
     for input_len in 40..100 {
         roundtrip_random(&mut byte_buf, &mut str_buf, &engine, input_len, 4, 1000);
@@ -120,7 +120,7 @@ fn roundtrip_decode_trailing_10_bytes() {
         let mut s: String = "ABCD".repeat(num_quads);
         s.push_str("EFGHIJKLZg");
 
-        let engine = GeneralPurpose::from(&STANDARD, NO_PAD);
+        let engine = GeneralPurpose::new(&STANDARD, NO_PAD);
         let decoded = decode_engine(&s, &engine).unwrap();
         assert_eq!(num_quads * 3 + 7, decoded.len());
 
@@ -139,7 +139,7 @@ fn display_wrapper_matches_normal_encode() {
 
     assert_eq!(
         encode(&bytes),
-        format!("{}", display::Base64Display::from(&bytes, &DEFAULT_ENGINE))
+        format!("{}", display::Base64Display::new(&bytes, &DEFAULT_ENGINE))
     );
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,6 @@
 use rand::{Rng, SeedableRng};
 
-use base64::engine::{Engine, STANDARD};
+use base64::engine::{general_purpose::STANDARD, Engine};
 use base64::*;
 
 use base64::engine::general_purpose::{GeneralPurpose, NO_PAD};


### PR DESCRIPTION
- [x] Incorporate feedback from https://github.com/marshallpierce/rust-base64/issues/205
  - [x] Rename FastPortable
  - [x] Move encode and decode to methods
  - [x] Consts for common engine arrangements
  - [x] Better samples in top level docs
- [x] Doc improvements from https://github.com/marshallpierce/rust-base64/issues/206
  - [x] More details on padding changes (implicit indifferent)
- [x] Error instead of panicking from https://github.com/marshallpierce/rust-base64/issues/192