### PR TITLE
Switch to non-overflowing decoded length formula

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,7 @@
+# 0.21.1
+
+- Remove the possibility of panicking during decoded length calculations
+
 # 0.21.0
 
 ## Migration

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -148,11 +148,6 @@ pub fn decode_engine_slice<E: Engine, T: AsRef<[u8]>>(
 /// // start of the next quad of encoded symbols
 /// assert_eq!(6, decoded_len_estimate(5));
 /// ```
-///
-/// # Panics
-///
-/// Panics if decoded length estimation overflows.
-/// This would happen for sizes within a few bytes of the maximum value of `usize`.
 pub fn decoded_len_estimate(encoded_len: usize) -> usize {
     STANDARD
         .internal_decoded_len_estimate(encoded_len)

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -62,10 +62,6 @@ pub trait Engine: Send + Sync {
     /// As an optimization to prevent the decoded length from being calculated twice, it is
     /// sometimes helpful to have a conservative estimate of the decoded size before doing the
     /// decoding, so this calculation is done separately and passed to [Engine::decode()] as needed.
-    ///
-    /// # Panics
-    ///
-    /// Panics if decoded length estimation overflows.
     #[doc(hidden)]
     fn internal_decoded_len_estimate(&self, input_len: usize) -> Self::DecodeEstimate;
 
@@ -225,11 +221,6 @@ pub trait Engine: Send + Sync {
     ///     .decode("aGVsbG8gaW50ZXJuZXR-Cg").unwrap();
     /// println!("{:?}", bytes_url);
     /// ```
-    ///
-    /// # Panics
-    ///
-    /// Panics if decoded length estimation overflows.
-    /// This would happen for sizes within a few bytes of the maximum value of `usize`.
     #[cfg(any(feature = "alloc", feature = "std", test))]
     fn decode<T: AsRef<[u8]>>(&self, input: T) -> Result<Vec<u8>, DecodeError> {
         let input_bytes = input.as_ref();
@@ -272,11 +263,6 @@ pub trait Engine: Send + Sync {
     ///     println!("{:?}", buffer);
     /// }
     /// ```
-    ///
-    /// # Panics
-    ///
-    /// Panics if decoded length estimation overflows.
-    /// This would happen for sizes within a few bytes of the maximum value of `usize`.
     #[cfg(any(feature = "alloc", feature = "std", test))]
     fn decode_vec<T: AsRef<[u8]>>(
         &self,
@@ -312,11 +298,6 @@ pub trait Engine: Send + Sync {
     ///
     /// See [Engine::decode_slice_unchecked] for a version that panics instead of returning an error
     /// if the output buffer is too small.
-    ///
-    /// # Panics
-    ///
-    /// Panics if decoded length estimation overflows.
-    /// This would happen for sizes within a few bytes of the maximum value of `usize`.
     fn decode_slice<T: AsRef<[u8]>>(
         &self,
         input: T,
@@ -343,9 +324,6 @@ pub trait Engine: Send + Sync {
     /// buffer is too small.
     ///
     /// # Panics
-    ///
-    /// Panics if decoded length estimation overflows.
-    /// This would happen for sizes within a few bytes of the maximum value of `usize`.
     ///
     /// Panics if the provided output buffer is too small for the decoded data.
     fn decode_slice_unchecked<T: AsRef<[u8]>>(
@@ -387,11 +365,6 @@ pub trait DecodeEstimate {
     ///
     /// The estimate must be no larger than the next largest complete triple of decoded bytes.
     /// That is, the final quad of tokens to decode may be assumed to be complete with no padding.
-    ///
-    /// # Panics
-    ///
-    /// Panics if decoded length estimation overflows.
-    /// This would happen for sizes within a few bytes of the maximum value of `usize`.
     fn decoded_len_estimate(&self) -> usize;
 }
 

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -26,10 +26,9 @@ fn encode_all_ascii() {
 fn encode_all_bytes() {
     let mut bytes = Vec::<u8>::with_capacity(256);
 
-    for i in 0..255 {
+    for i in 0..=255 {
         bytes.push(i);
     }
-    bytes.push(255); //bug with "overflowing" ranges?
 
     compare_encode(
         "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7P\
@@ -44,10 +43,9 @@ fn encode_all_bytes() {
 fn encode_all_bytes_url() {
     let mut bytes = Vec::<u8>::with_capacity(256);
 
-    for i in 0..255 {
+    for i in 0..=255 {
         bytes.push(i);
     }
-    bytes.push(255); //bug with "overflowing" ranges?
 
     assert_eq!(
         "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0\


### PR DESCRIPTION
No change to benchmarks.

Motivated by the alternate approach in https://github.com/marshallpierce/rust-base64/pull/216/.