### PR TITLE
Simplify chunk_encoder

### DIFF
--- a/src/chunked_encoder.rs
+++ b/src/chunked_encoder.rs
@@ -1,10 +1,8 @@
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use alloc::string::String;
-use core::cmp;
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use core::str;
 
-use crate::encode::add_padding;
 use crate::engine::{Config, Engine};
 
 /// The output mechanism for ChunkedEncoder's encoded bytes.
@@ -15,69 +13,37 @@ pub trait Sink {
     fn write_encoded_bytes(&mut self, encoded: &[u8]) -> Result<(), Self::Error>;
 }
 
-const BUF_SIZE: usize = 1024;
-
 /// A base64 encoder that emits encoded bytes in chunks without heap allocation.
 pub struct ChunkedEncoder<'e, E: Engine + ?Sized> {
     engine: &'e E,
-    max_input_chunk_len: usize,
 }
 
 impl<'e, E: Engine + ?Sized> ChunkedEncoder<'e, E> {
     pub fn new(engine: &'e E) -> ChunkedEncoder<'e, E> {
-        ChunkedEncoder {
-            engine,
-            max_input_chunk_len: max_input_length(BUF_SIZE, engine.config().encode_padding()),
-        }
+        ChunkedEncoder { engine }
     }
 
     pub fn encode<S: Sink>(&self, bytes: &[u8], sink: &mut S) -> Result<(), S::Error> {
-        let mut encode_buf: [u8; BUF_SIZE] = [0; BUF_SIZE];
-        let mut input_index = 0;
+        const BUF_SIZE: usize = 1024;
+        const CHUNK_SIZE: usize = BUF_SIZE / 4 * 3;
 
-        while input_index < bytes.len() {
-            // either the full input chunk size, or it's the last iteration
-            let input_chunk_len = cmp::min(self.max_input_chunk_len, bytes.len() - input_index);
-
-            let chunk = &bytes[input_index..(input_index + input_chunk_len)];
-
-            let mut b64_bytes_written = self.engine.internal_encode(chunk, &mut encode_buf);
-
-            input_index += input_chunk_len;
-            let more_input_left = input_index < bytes.len();
-
-            if self.engine.config().encode_padding() && !more_input_left {
-                // no more input, add padding if needed. Buffer will have room because
-                // max_input_length leaves room for it.
-                b64_bytes_written += add_padding(bytes.len(), &mut encode_buf[b64_bytes_written..]);
+        let mut buf = [0; BUF_SIZE];
+        for chunk in bytes.chunks(CHUNK_SIZE) {
+            let mut len = self.engine.internal_encode(chunk, &mut buf);
+            if chunk.len() != CHUNK_SIZE && self.engine.config().encode_padding() {
+                // Final, potentially partial, chunk.  Pad output to multiple of
+                // four bytes if required by config.
+                let padding = 4 - (len % 4);
+                if padding != 4 {
+                    buf[len..(len + padding)].fill(crate::PAD_BYTE);
+                    len += padding;
+                }
             }
-
-            sink.write_encoded_bytes(&encode_buf[0..b64_bytes_written])?;
+            sink.write_encoded_bytes(&buf[..len])?;
         }
 
         Ok(())
     }
-}
-
-/// Calculate the longest input that can be encoded for the given output buffer size.
-///
-/// If the config requires padding, two bytes of buffer space will be set aside so that the last
-/// chunk of input can be encoded safely.
-///
-/// The input length will always be a multiple of 3 so that no encoding state has to be carried over
-/// between chunks.
-fn max_input_length(encoded_buf_len: usize, padded: bool) -> usize {
-    let effective_buf_len = if padded {
-        // make room for padding
-        encoded_buf_len
-            .checked_sub(2)
-            .expect("Don't use a tiny buffer")
-    } else {
-        encoded_buf_len
-    };
-
-    // No padding, so just normal base64 expansion.
-    (effective_buf_len / 4) * 3
 }
 
 // A really simple sink that just appends to a string
@@ -149,31 +115,6 @@ pub mod tests {
     fn chunked_encode_matches_normal_encode_random_string_sink() {
         let helper = StringSinkTestHelper;
         chunked_encode_matches_normal_encode_random(&helper);
-    }
-
-    #[test]
-    fn max_input_length_no_pad() {
-        assert_eq!(768, max_input_length(1024, false));
-    }
-
-    #[test]
-    fn max_input_length_with_pad_decrements_one_triple() {
-        assert_eq!(765, max_input_length(1024, true));
-    }
-
-    #[test]
-    fn max_input_length_with_pad_one_byte_short() {
-        assert_eq!(765, max_input_length(1025, true));
-    }
-
-    #[test]
-    fn max_input_length_with_pad_fits_exactly() {
-        assert_eq!(768, max_input_length(1026, true));
-    }
-
-    #[test]
-    fn max_input_length_cant_use_extra_single_encoded_byte() {
-        assert_eq!(300, max_input_length(401, false));
     }
 
     pub fn chunked_encode_matches_normal_encode_random<S: SinkTestHelper>(sink_test_helper: &S) {


### PR DESCRIPTION
Firstly, use `[T]::chunks` rather than doing index calculation
manually.

Secondly, get rid of max_input_length.  The function was overly
complicated for no reason.  After all, no matter whether engine uses
padding or not, N-byte output buffer can accommodate (N/4*3) input
bytes.

Encode benchmarks here are kind of all over.  Some improvements and
some regressions:

    encode/
               3   29.272 ns   -0.4%   No change
              50   54.162 ns  +12.4%   Regression
             100   95.488 ns   -7.8%   Improvement
             500   255.84 ns   +3.5%   Regression
            3072   1.3527 µs   +0.1%   No change
         3145728   1.4584 ms   +0.2%   Within noise
        10485760   4.8923 ms   +1.6%   Regression
        31457280   16.087 ms   -2.6%   Improvement

    encode_display/
               3   41.038 ns   -6.9%   Improvement
              50   70.877 ns   +7.2%   Regression
             100   91.190 ns   +1.1%   Within noise
             500   264.58 ns   -3.1%   Improvement
            3072   1.4515 µs   -3.8%   Improvement
         3145728   1.4239 ms   -0.2%   Within noise
        10485760   4.9768 ms   -0.7%   Within noise
        31457280   18.202 ms   -1.5%   Improvement

    encode_reuse_buf/
               3   20.264 ns  -23.1%   Improvement
              50   46.631 ns   +2.1%   Regression
             100   66.405 ns   -2.0%   Improvement
             500   243.52 ns   +3.5%   Regression
            3072   1.3871 µs   -1.2%   Within noise
         3145728   1.4278 ms   +0.8%   Within noise
        10485760   5.0530 ms   -1.6%   Improvement
        31457280   15.798 ms   +0.7%   No change

    encode_reuse_buf_stream/
               3   21.007 ns   +1.1%   Regression
              50   56.542 ns   -0.9%   No change
             100   75.214 ns   -1.4%   Improvement
             500   247.61 ns   -4.2%   Improvement
            3072   1.2836 µs   +0.1%   No change
         3145728   1.3177 ms   -0.5%   Within noise
        10485760   4.3843 ms   +0.3%   Within noise
        31457280   14.058 ms   -0.5%   Within noise

    encode_slice/
               3   11.859 ns   +0.1%   No change
              50   30.239 ns   +2.8%   Regression
             100   53.383 ns   -6.4%   Improvement
             500   207.90 ns   +0.2%   No change
            3072   1.2050 µs   -0.1%   Within noise
         3145728   1.2294 ms   -0.5%   Within noise
        10485760   4.1025 ms   -0.1%   No change
        31457280   12.352 ms   +0.1%   Within noise

    encode_string_reuse_buf_stream/
               3   39.237 ns   -0.9%   Within noise
              50   100.15 ns   -1.6%   Improvement
             100   124.03 ns   +3.5%   Regression
             500   312.15 ns  +10.0%   Regression
            3072   1.4781 µs   +2.7%   Regression
         3145728   1.4942 ms   +3.8%   Regression
        10485760   4.9965 ms   +4.3%   Regression
        31457280   16.990 ms   +7.4%   Regression

    encode_string_stream/
               3   48.437 ns   -4.2%   Improvement
              50   152.06 ns   +3.5%   Regression
             100   170.02 ns   -5.2%   Improvement
             500   324.46 ns   -0.8%   Within noise
            3072   1.5332 µs   +1.6%   Regression
         3145728   1.4947 ms   +3.6%   Regression
        10485760   4.9710 ms   +3.2%   Regression
        31457280   19.075 ms   +2.2%   Regression
