### PR TITLE
Remove the irrelevant message from RELEASE-NOTES.md

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,8 +1,5 @@
 # 0.21.0
 
-(not yet released)
-
-
 ## Migration
 
 ### Functions


### PR DESCRIPTION
Removed the message that says version 0.21.0 has not yet been released.