### PR TITLE
decode: use exact decoded length rather than estimation

### DIFF
--- a/src/engine/general_purpose/decode_suffix.rs
+++ b/src/engine/general_purpose/decode_suffix.rs
@@ -6,8 +6,9 @@ use crate::{
 /// Decode the last 1-8 bytes, checking for trailing set bits and padding per the provided
 /// parameters.
 ///
-/// Returns the total number of bytes decoded, including the ones indicated as already written by
-/// `output_index`.
+/// Expects output to be large enough to fit decoded data exactly without any
+/// unused space.  In debug builds panics if final output length (`output_index`
+/// plus any bytes written by this function) doesn’t equal length of the output.
 pub(crate) fn decode_suffix(
     input: &[u8],
     input_index: usize,
@@ -16,7 +17,7 @@ pub(crate) fn decode_suffix(
     decode_table: &[u8; 256],
     decode_allow_trailing_bits: bool,
     padding_mode: DecodePaddingMode,
-) -> Result<usize, DecodeError> {
+) -> Result<(), DecodeError> {
     // Decode any leftovers that aren't a complete input block of 8 bytes.
     // Use a u64 as a stack-resident 8 byte buffer.
     let mut leftover_bits: u64 = 0;
@@ -157,5 +158,6 @@ pub(crate) fn decode_suffix(
         leftover_bits_appended_to_buf += 8;
     }
 
-    Ok(output_index)
+    debug_assert_eq!(output.len(), output_index);
+    Ok(())
 }

--- a/src/engine/general_purpose/mod.rs
+++ b/src/engine/general_purpose/mod.rs
@@ -9,7 +9,6 @@ use core::convert::TryInto;
 
 mod decode;
 pub(crate) mod decode_suffix;
-pub use decode::GeneralPurposeEstimate;
 
 pub(crate) const INVALID_VALUE: u8 = 255;
 
@@ -40,7 +39,6 @@ impl GeneralPurpose {
 
 impl super::Engine for GeneralPurpose {
     type Config = GeneralPurposeConfig;
-    type DecodeEstimate = GeneralPurposeEstimate;
 
     fn internal_encode(&self, input: &[u8], output: &mut [u8]) -> usize {
         let mut input_index: usize = 0;
@@ -161,19 +159,9 @@ impl super::Engine for GeneralPurpose {
         output_index
     }
 
-    fn internal_decoded_len_estimate(&self, input_len: usize) -> Self::DecodeEstimate {
-        GeneralPurposeEstimate::new(input_len)
-    }
-
-    fn internal_decode(
-        &self,
-        input: &[u8],
-        output: &mut [u8],
-        estimate: Self::DecodeEstimate,
-    ) -> Result<usize, DecodeError> {
+    fn internal_decode(&self, input: &[u8], output: &mut [u8]) -> Result<(), DecodeError> {
         decode::decode_helper(
             input,
-            estimate,
             output,
             &self.decode_table,
             self.config.decode_allow_trailing_bits,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,9 @@ mod decode;
 #[cfg(any(feature = "alloc", feature = "std", test))]
 pub use crate::decode::{decode, decode_engine, decode_engine_vec};
 #[allow(deprecated)]
-pub use crate::decode::{decode_engine_slice, decoded_len_estimate, DecodeError, DecodeSliceError};
+pub use crate::decode::{
+    decode_engine_slice, decoded_len, decoded_len_estimate, DecodeError, DecodeSliceError,
+};
 
 pub mod prelude;
 

--- a/src/read/decoder.rs
+++ b/src/read/decoder.rs
@@ -132,13 +132,10 @@ impl<'e, E: Engine, R: io::Read> DecoderReader<'e, E, R> {
         debug_assert!(self.b64_offset + self.b64_len <= BUF_SIZE);
         debug_assert!(!buf.is_empty());
 
-        let decoded = self
-            .engine
-            .internal_decode(
-                &self.b64_buffer[self.b64_offset..self.b64_offset + num_bytes],
-                buf,
-                self.engine.internal_decoded_len_estimate(num_bytes),
-            )
+        let input_bytes = &self.b64_buffer[self.b64_offset..self.b64_offset + num_bytes];
+        let decoded = crate::decoded_len(input_bytes);
+        self.engine
+            .internal_decode(input_bytes, &mut buf[..decoded])
             .map_err(|e| match e {
                 DecodeError::InvalidByte(offset, byte) => {
                     DecodeError::InvalidByte(self.total_b64_decoded + offset, byte)


### PR DESCRIPTION
Fixes: https://github.com/marshallpierce/rust-base64/issues/210
Fixes: https://github.com/marshallpierce/rust-base64/issues/212