### PR TITLE
Replace internal buffer in decoder with `BufRead`

### DIFF
--- a/examples/base64.rs
+++ b/examples/base64.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::{self, Read};
+use std::io::{self, BufRead, BufReader};
 use std::path::PathBuf;
 use std::process;
 use std::str::FromStr;
@@ -48,7 +48,7 @@ struct Opt {
 fn main() {
     let opt = Opt::from_args();
     let stdin;
-    let mut input: Box<dyn Read> = match opt.file {
+    let mut input: Box<dyn BufRead> = match opt.file {
         None => {
             stdin = io::stdin();
             Box::new(stdin.lock())
@@ -57,7 +57,7 @@ fn main() {
             stdin = io::stdin();
             Box::new(stdin.lock())
         }
-        Some(f) => Box::new(File::open(f).unwrap()),
+        Some(f) => Box::new(File::open(f).map(BufReader::new).unwrap()),
     };
 
     let alphabet = opt.alphabet.unwrap_or_default();


### PR DESCRIPTION
The `DecoderReader` used an internal buffer for reading which came with a number of disadvantages, such as:

* Needless copying from in-memory readers (slices)
* Double-buffering already-buffered readers
* The bytes are lost when dropping or calling `into_inner`
* `BUF_SIZE` is not configurable
* `std::io::BufReader` has access to some unstable optimizations which this crate cannot use
* Reinvents the wheel; there already is `std::io::BufReader`

This change removes it and requires `BufRead` instead. Decoding is implemented on top of `fill_buf` for larger chunks with fallback to small, stack-allocated buffer for tiny chunks that may appear at boundaries.

To resolve borrowing problems `decode_to_buf` had to be removed which also enabled decoding bytes directly into internal buffer when the buffer to be filled is small rather than into a temporary buffer which is then copied.

This improves performance of reading by around 7-22% on my machine.

Closes #230 