### PR TITLE
Implement `source` instead of `cause` on std::error::Error types

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -41,11 +41,7 @@ impl fmt::Display for DecodeError {
 }
 
 #[cfg(any(feature = "std", test))]
-impl error::Error for DecodeError {
-    fn cause(&self) -> Option<&dyn error::Error> {
-        None
-    }
-}
+impl error::Error for DecodeError {}
 
 /// Errors that can occur while decoding into a slice.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -69,7 +65,7 @@ impl fmt::Display for DecodeSliceError {
 
 #[cfg(any(feature = "std", test))]
 impl error::Error for DecodeSliceError {
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
             DecodeSliceError::DecodeError(e) => Some(e),
             DecodeSliceError::OutputSliceTooSmall => None,

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -149,11 +149,7 @@ impl fmt::Display for EncodeSliceError {
 }
 
 #[cfg(any(feature = "std", test))]
-impl error::Error for EncodeSliceError {
-    fn cause(&self) -> Option<&dyn error::Error> {
-        None
-    }
-}
+impl error::Error for EncodeSliceError {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
The `cause` method has been deprecated since Rust 1.33.0 and has been replaced by `source`.  The `cause` method's default implementation calls `source` so there is no need to implement them both.

On types which always return `None` in `source`, the implementation has been removed because the default implementation does exactly this.