### PR TITLE
Add `--generate-link-to-definition` option when building on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ rust-version = "1.57.0"
 name = "benchmarks"
 harness = false
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]
+
 [dev-dependencies]
 criterion = "0.4.0"
 rand = { version = "0.8.5", features = ["small_rng"] }


### PR DESCRIPTION
This option generates links in source code pages, allowing to jump to definition and to jump back to doc. It makes browsing the source code pages much nicer. You can see it in action [here](https://doc.rust-lang.org/stable/nightly-rustc/src/rustc_middle/lib.rs.html#90).