### PR TITLE
Roll back the MSRV to Rust 1.48

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ workflows:
                 # be easier on the CI hosts since presumably those fat lower layers will already be cached, and
                 # therefore faster than a minimal, customized alpine.
                 # MSRV
-                'rust:1.57.0'
+                'rust:1.48.0'
               ]
               # a hacky scheme to work around CircleCI's inability to deal with mutable docker tags, forcing us to
               # get a nightly or stable toolchain via rustup instead of a mutable docker tag
@@ -89,7 +89,7 @@ jobs:
           name: Build ARM with only alloc feature
           command: cargo build --target thumbv6m-none-eabi --no-default-features --features alloc
       - run:
-          # dev dependencies can't build on 1.57.0
+          # dev dependencies can't build on 1.48.0
           name: Run tests
           command: |
             if [[ '<< parameters.toolchain_override >>' != '__msrv__' ]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,10 @@ readme = "README.md"
 keywords = ["base64", "utf8", "encode", "decode", "no_std"]
 categories = ["encoding"]
 license = "MIT OR Apache-2.0"
-edition = "2021"
+edition = "2018"
 # dev-dependencies require 1.60, but the main code doesn't
-rust-version = "1.57.0"
+# This option was added in 1.56, keep it for when we bump MSRV.
+rust-version = "1.48.0"
 
 [[bench]]
 name = "benchmarks"

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ optionally may allow other behaviors.
 
 ## Rust version compatibility
 
-The minimum supported Rust version is 1.57.0.
+The minimum supported Rust version is 1.48.0.
 
 # Contributing
 

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -1,6 +1,7 @@
 //! Provides [Alphabet] and constants for alphabets commonly used in the wild.
 
 use crate::PAD_BYTE;
+use core::convert::TryFrom;
 use core::fmt;
 #[cfg(any(feature = "std", test))]
 use std::error;
@@ -171,7 +172,6 @@ pub const BIN_HEX: Alphabet = Alphabet::from_str_unchecked(
 #[cfg(test)]
 mod tests {
     use crate::alphabet::*;
-    use std::convert::TryFrom as _;
 
     #[test]
     fn detects_duplicate_start() {


### PR DESCRIPTION
The current MSRV (for non-dev builds) is Rust 1.57 however the codebase does not use any features from edition 2021 (landed Rust 1.56) except the `TryFrom` trait.

If we explicitly import `core::convert::tryFrom` we can stay on edition 2018.

The `rust-version` manifest option was added in Rust 1.56 but lets leave it there as added documentation of the MSRV and in preparation for bumping the MSRV when needed.

Rust 1.48 is a suitably old toolchain version, it is the toolchain included in Debian Bullseye.
