### PR TITLE
Simplify `cfg`s and allow testing without default features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,19 @@ rust-version = "1.48.0"
 [[bench]]
 name = "benchmarks"
 harness = false
+required-features = ["std"]
+
+[[example]]
+name = "base64"
+required-features = ["std"]
+
+[[test]]
+name = "tests"
+required-features = ["alloc"]
+
+[[test]]
+name = "encode"
+required-features = ["alloc"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--generate-link-to-definition"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ lazy_static = "1.4.0"
 [features]
 default = ["std"]
 alloc = []
-std = []
+std = ["alloc"]
 
 [profile.bench]
 # Useful for better disassembly when using `perf record` and `perf annotate`

--- a/src/chunked_encoder.rs
+++ b/src/chunked_encoder.rs
@@ -2,9 +2,9 @@ use crate::{
     encode::add_padding,
     engine::{Config, Engine},
 };
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", test))]
 use alloc::string::String;
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", test))]
 use core::str;
 
 /// The output mechanism for ChunkedEncoder's encoded bytes.
@@ -47,19 +47,19 @@ impl<'e, E: Engine + ?Sized> ChunkedEncoder<'e, E> {
 }
 
 // A really simple sink that just appends to a string
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", test))]
 pub(crate) struct StringSink<'a> {
     string: &'a mut String,
 }
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", test))]
 impl<'a> StringSink<'a> {
     pub(crate) fn new(s: &mut String) -> StringSink {
         StringSink { string: s }
     }
 }
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", test))]
 impl<'a> Sink for StringSink<'a> {
     type Error = ();
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,5 +1,5 @@
 use crate::engine::{general_purpose::STANDARD, DecodeEstimate, Engine};
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", test))]
 use alloc::vec::Vec;
 use core::fmt;
 #[cfg(any(feature = "std", test))]
@@ -83,7 +83,7 @@ impl From<DecodeError> for DecodeSliceError {
 ///
 /// See [Engine::decode].
 #[deprecated(since = "0.21.0", note = "Use Engine::decode")]
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", test))]
 pub fn decode<T: AsRef<[u8]>>(input: T) -> Result<Vec<u8>, DecodeError> {
     STANDARD.decode(input)
 }
@@ -93,7 +93,7 @@ pub fn decode<T: AsRef<[u8]>>(input: T) -> Result<Vec<u8>, DecodeError> {
 /// See [Engine::decode].
 ///Returns a `Result` containing a `Vec<u8>`.
 #[deprecated(since = "0.21.0", note = "Use Engine::decode")]
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", test))]
 pub fn decode_engine<E: Engine, T: AsRef<[u8]>>(
     input: T,
     engine: &E,
@@ -104,7 +104,7 @@ pub fn decode_engine<E: Engine, T: AsRef<[u8]>>(
 /// Decode from string reference as octets.
 ///
 /// See [Engine::decode_vec].
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", test))]
 #[deprecated(since = "0.21.0", note = "Use Engine::decode_vec")]
 pub fn decode_engine_vec<E: Engine, T: AsRef<[u8]>>(
     input: T,

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1,10 +1,10 @@
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", test))]
 use alloc::string::String;
 use core::fmt;
 #[cfg(any(feature = "std", test))]
 use std::error;
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", test))]
 use crate::engine::general_purpose::STANDARD;
 use crate::engine::{Config, Engine};
 use crate::PAD_BYTE;
@@ -14,7 +14,7 @@ use crate::PAD_BYTE;
 /// See [Engine::encode].
 #[allow(unused)]
 #[deprecated(since = "0.21.0", note = "Use Engine::encode")]
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", test))]
 pub fn encode<T: AsRef<[u8]>>(input: T) -> String {
     STANDARD.encode(input)
 }
@@ -24,7 +24,7 @@ pub fn encode<T: AsRef<[u8]>>(input: T) -> String {
 /// See [Engine::encode].
 #[allow(unused)]
 #[deprecated(since = "0.21.0", note = "Use Engine::encode")]
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", test))]
 pub fn encode_engine<E: Engine, T: AsRef<[u8]>>(input: T, engine: &E) -> String {
     engine.encode(input)
 }
@@ -34,7 +34,7 @@ pub fn encode_engine<E: Engine, T: AsRef<[u8]>>(input: T, engine: &E) -> String 
 /// See [Engine::encode_string].
 #[allow(unused)]
 #[deprecated(since = "0.21.0", note = "Use Engine::encode_string")]
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", test))]
 pub fn encode_engine_string<E: Engine, T: AsRef<[u8]>>(
     input: T,
     output_buf: &mut String,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,14 +1,14 @@
 //! Provides the [Engine] abstraction and out of the box implementations.
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", test))]
 use crate::chunked_encoder;
 use crate::{
     encode::{encode_with_padding, EncodeSliceError},
     encoded_len, DecodeError, DecodeSliceError,
 };
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", test))]
 use alloc::vec::Vec;
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", test))]
 use alloc::{string::String, vec};
 
 pub mod general_purpose;
@@ -113,7 +113,7 @@ pub trait Engine: Send + Sync {
     ///     engine::GeneralPurpose::new(&alphabet::URL_SAFE, general_purpose::NO_PAD);
     ///
     /// let b64_url = CUSTOM_ENGINE.encode(b"hello internet~");
-    #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg(any(feature = "alloc", test))]
     #[inline]
     fn encode<T: AsRef<[u8]>>(&self, input: T) -> String {
         fn inner<E>(engine: &E, input_bytes: &[u8]) -> String
@@ -153,7 +153,7 @@ pub trait Engine: Send + Sync {
     ///     println!("{}", buf);
     /// }
     /// ```
-    #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg(any(feature = "alloc", test))]
     #[inline]
     fn encode_string<T: AsRef<[u8]>>(&self, input: T, output_buf: &mut String) {
         fn inner<E>(engine: &E, input_bytes: &[u8], output_buf: &mut String)
@@ -241,7 +241,7 @@ pub trait Engine: Send + Sync {
     ///     .decode("aGVsbG8gaW50ZXJuZXR-Cg").unwrap();
     /// println!("{:?}", bytes_url);
     /// ```
-    #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg(any(feature = "alloc", test))]
     #[inline]
     fn decode<T: AsRef<[u8]>>(&self, input: T) -> Result<Vec<u8>, DecodeError> {
         fn inner<E>(engine: &E, input_bytes: &[u8]) -> Result<Vec<u8>, DecodeError>
@@ -293,7 +293,7 @@ pub trait Engine: Send + Sync {
     ///     println!("{:?}", buffer);
     /// }
     /// ```
-    #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg(any(feature = "alloc", test))]
     #[inline]
     fn decode_vec<T: AsRef<[u8]>>(
         &self,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -178,7 +178,8 @@ pub trait Engine: Send + Sync {
     ///
     /// # Example
     ///
-    /// ```rust
+    #[cfg_attr(feature = "alloc", doc = "```")]
+    #[cfg_attr(not(feature = "alloc"), doc = "```ignore")]
     /// use base64::{Engine as _, engine::general_purpose};
     /// let s = b"hello internet!";
     /// let mut buf = Vec::new();

--- a/src/engine/naive.rs
+++ b/src/engine/naive.rs
@@ -6,8 +6,7 @@ use crate::{
     },
     DecodeError, PAD_BYTE,
 };
-use alloc::ops::BitOr;
-use std::ops::{BitAnd, Shl, Shr};
+use std::ops::{BitAnd, BitOr, Shl, Shr};
 
 /// Comparatively simple implementation that can be used as something to compare against in tests
 pub struct Naive {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,10 +136,8 @@
 #![allow(clippy::single_component_path_imports)]
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 
-#[cfg(all(feature = "alloc", not(any(feature = "std", test))))]
+#[cfg(any(feature = "alloc", test))]
 extern crate alloc;
-#[cfg(any(feature = "std", test))]
-extern crate std as alloc;
 
 // has to be included at top level because of the way rstest_reuse defines its macros
 #[cfg(test)]
@@ -159,14 +157,14 @@ pub mod alphabet;
 
 mod encode;
 #[allow(deprecated)]
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", test))]
 pub use crate::encode::{encode, encode_engine, encode_engine_string};
 #[allow(deprecated)]
 pub use crate::encode::{encode_engine_slice, encoded_len, EncodeSliceError};
 
 mod decode;
 #[allow(deprecated)]
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", test))]
 pub use crate::decode::{decode, decode_engine, decode_engine_vec};
 #[allow(deprecated)]
 pub use crate::decode::{decode_engine_slice, decoded_len_estimate, DecodeError, DecodeSliceError};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,8 @@
 //!
 //! ## Using predefined engines
 //!
-//! ```
+#![cfg_attr(feature = "alloc", doc = "```")]
+#![cfg_attr(not(feature = "alloc"), doc = "```ignore")]
 //! use base64::{Engine as _, engine::general_purpose};
 //!
 //! let orig = b"data";
@@ -95,7 +96,8 @@
 //!
 //! ## Custom alphabet, config, and engine
 //!
-//! ```
+#![cfg_attr(feature = "alloc", doc = "```")]
+#![cfg_attr(not(feature = "alloc"), doc = "```ignore")]
 //! use base64::{engine, alphabet, Engine as _};
 //!
 //! // bizarro-world base64: +/ as the first symbols instead of the last

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -5,7 +5,8 @@
 //!
 //! # Examples
 //!
-//! ```
+#![cfg_attr(feature = "alloc", doc = "```")]
+#![cfg_attr(not(feature = "alloc"), doc = "```ignore")]
 //! use base64::prelude::{Engine as _, BASE64_STANDARD_NO_PAD};
 //!
 //! assert_eq!("c29tZSBieXRlcw", &BASE64_STANDARD_NO_PAD.encode(b"some bytes"));


### PR DESCRIPTION
This PR contains two commits which address different matters, but the second depends on and helps test the first. If desired, I can split it into two PRs, or discard either one and keep the other.

---

First: `no_std` import simplification.

It's always OK to use `core` and `alloc` if you're using `std`, and `core` if you're using `alloc`. Therefore, code can be simplified by using `alloc` even if `std` is also being used, and so on.

* Make `std` feature depend on `alloc` feature.
* Simplify `cfg()`s by making that assumption.
* Don't import `std` aliased as `alloc`; use `alloc` directly.

These changes do not affect the public API of the crate in any way, but should make maintenance slightly easier since there are fewer subtly-different conditions under which the code might be compiled.

---

Second: Allow `cargo test` to complete under any set of features. 

Previously, tests, examples, and benches would fail to compile under `cargo test --no-default-features`. Now they are all skipped if they would not compile.

This does not affect behavior *with* default features — test coverage is not reduced.