### PR TITLE
Update example to use clap 4, replace lazy_static with once_cell, update other dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,13 +35,13 @@ required-features = ["alloc"]
 rustdoc-args = ["--generate-link-to-definition"]
 
 [dev-dependencies]
-criterion = "0.4.0"
+criterion = "0.5"
 rand = { version = "0.8.5", features = ["small_rng"] }
-structopt = "0.3.26"
+clap = { version = "4", features = ["derive"] }
 # test fixtures for engine tests
-rstest = "0.12.0"
-rstest_reuse = "0.3.0"
-lazy_static = "1.4.0"
+rstest = "0.18.0"
+rstest_reuse = "0.6.0"
+once_cell = "1"
 
 [features]
 default = ["std"]

--- a/examples/base64.rs
+++ b/examples/base64.rs
@@ -5,18 +5,13 @@ use std::process;
 use std::str::FromStr;
 
 use base64::{alphabet, engine, read, write};
-use structopt::StructOpt;
+use clap::{self, Parser};
 
-#[derive(Debug, StructOpt)]
+#[derive(Copy, Clone, Debug, Default, Parser)]
 enum Alphabet {
+    #[default]
     Standard,
     UrlSafe,
-}
-
-impl Default for Alphabet {
-    fn default() -> Self {
-        Self::Standard
-    }
 }
 
 impl FromStr for Alphabet {
@@ -31,22 +26,22 @@ impl FromStr for Alphabet {
 }
 
 /// Base64 encode or decode FILE (or standard input), to standard output.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Opt {
     /// decode data
-    #[structopt(short = "d", long = "decode")]
+    #[arg(short, long)]
     decode: bool,
     /// The alphabet to choose. Defaults to the standard base64 alphabet.
     /// Supported alphabets include "standard" and "urlsafe".
-    #[structopt(long = "alphabet")]
+    #[arg(short, long)]
     alphabet: Option<Alphabet>,
     /// The file to encode/decode.
-    #[structopt(parse(from_os_str))]
+    #[arg(short, long)]
     file: Option<PathBuf>,
 }
 
 fn main() {
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
     let stdin;
     let mut input: Box<dyn Read> = match opt.file {
         None => {

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -38,17 +38,18 @@ const ALPHABET_SIZE: usize = 64;
 /// };
 /// ```
 ///
-/// Building a lazy_static:
+/// Building lazily:
 ///
 /// ```
 /// use base64::{
 ///     alphabet::Alphabet,
 ///     engine::{general_purpose::GeneralPurpose, GeneralPurposeConfig},
 /// };
+/// use once_cell::sync::Lazy;
 ///
-/// lazy_static::lazy_static! {
-///     static ref CUSTOM: Alphabet = Alphabet::new("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/").unwrap();
-/// }
+/// static CUSTOM: Lazy<Alphabet> = Lazy::new(||
+///     Alphabet::new("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/").unwrap()
+/// );
 /// ```
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Alphabet {


### PR DESCRIPTION
structopt crate was deprecated after being merged into clap v3