### PR TITLE
Minor doc improvements

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -98,7 +98,8 @@ pub const fn encoded_len(bytes_len: usize, padding: bool) -> Option<usize> {
     let rem = bytes_len % 3;
 
     let complete_input_chunks = bytes_len / 3;
-    // `let Some(_) = _ else` requires 1.65.0, whereas this messier one works on 1.48
+    // `?` is disallowed in const, and `let Some(_) = _ else` requires 1.65.0, whereas this
+    // messier syntax works on 1.48
     let complete_chunk_output =
         if let Some(complete_chunk_output) = complete_input_chunks.checked_mul(4) {
             complete_chunk_output

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@
 //!
 //! # `Display`
 //!
-//! See [display] for how to transparently base64 data via a `Display` implementation.
+//! See [display] for how to transparently base64-encode data via a `Display` implementation.
 //!
 //! # Examples
 //!


### PR DESCRIPTION
A different path than #256, but same idea.

Also a clarification for why encoded_len can't just use `?`.