### PR TITLE
examples: replace structopt with clap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,9 @@ rustdoc-args = ["--generate-link-to-definition"]
 [dev-dependencies]
 criterion = "0.4.0"
 rand = { version = "0.8.5", features = ["small_rng"] }
-structopt = "0.3.26"
+# Latest is 4.4.13 but specifies MSRV in Cargo.toml which means we can't depend
+# on it (even though we won't compile it in MSRV CI).
+clap = { version = "3.2.25", features = ["derive"] }
 # test fixtures for engine tests
 rstest = "0.13.0"
 rstest_reuse = "0.6.0"

--- a/examples/base64.rs
+++ b/examples/base64.rs
@@ -5,9 +5,9 @@ use std::process;
 use std::str::FromStr;
 
 use base64::{alphabet, engine, read, write};
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(Debug, StructOpt)]
+#[derive(Clone, Debug, Parser)]
 enum Alphabet {
     Standard,
     UrlSafe,
@@ -31,22 +31,21 @@ impl FromStr for Alphabet {
 }
 
 /// Base64 encode or decode FILE (or standard input), to standard output.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Opt {
     /// decode data
-    #[structopt(short = "d", long = "decode")]
+    #[structopt(short = 'd', long = "decode")]
     decode: bool,
     /// The alphabet to choose. Defaults to the standard base64 alphabet.
     /// Supported alphabets include "standard" and "urlsafe".
     #[structopt(long = "alphabet")]
     alphabet: Option<Alphabet>,
     /// The file to encode/decode.
-    #[structopt(parse(from_os_str))]
     file: Option<PathBuf>,
 }
 
 fn main() {
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
     let stdin;
     let mut input: Box<dyn Read> = match opt.file {
         None => {


### PR DESCRIPTION
See https://github.com/TeXitoi/structopt/issues/525.

Currently base64 is the most downloaded dependent of structopt:
https://crates.io/crates/structopt/reverse_dependencies.
