### PR TITLE
provide as_string() method to return the alphabet characters

### DIFF
--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -124,6 +124,7 @@ impl Alphabet {
         Ok(Self::from_str_unchecked(alphabet))
     }
 
+    /// Create a String from the symbols in the `Alphabet`
     pub fn as_string(&self) -> String {
         self.symbols.iter().map(|c| *c as char).collect::<String>()
     }

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -123,6 +123,10 @@ impl Alphabet {
 
         Ok(Self::from_str_unchecked(alphabet))
     }
+
+    pub fn as_string(&self) -> String {
+        self.symbols.iter().map(|c| *c as char).collect::<String>()
+    }
 }
 
 impl convert::TryFrom<&str> for Alphabet {
@@ -269,5 +273,14 @@ mod tests {
             Alphabet::try_from("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/")
                 .unwrap()
         );
+    }
+
+    #[test]
+    fn string_same_as_input() {
+        let alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+        let a = Alphabet::try_from(alphabet).unwrap();
+
+        assert_eq!(String::from(alphabet), a.as_string())
     }
 }

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -125,6 +125,7 @@ impl Alphabet {
     }
 
     /// Create a String from the symbols in the `Alphabet`
+    #[cfg(any(feature = "std", test))]
     pub fn as_string(&self) -> String {
         self.symbols.iter().map(|c| *c as char).collect::<String>()
     }

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -124,10 +124,9 @@ impl Alphabet {
         Ok(Self::from_str_unchecked(alphabet))
     }
 
-    /// Create a String from the symbols in the `Alphabet`
-    #[cfg(any(feature = "std", test))]
-    pub fn as_string(&self) -> String {
-        self.symbols.iter().map(|c| *c as char).collect::<String>()
+    /// Create a `&str` from the symbols in the `Alphabet`
+    pub fn as_str(&self) -> &str {
+        std::str::from_utf8(&self.symbols).unwrap()
     }
 }
 
@@ -278,11 +277,9 @@ mod tests {
     }
 
     #[test]
-    fn string_same_as_input() {
+    fn str_same_as_input() {
         let alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-
         let a = Alphabet::try_from(alphabet).unwrap();
-
-        assert_eq!(String::from(alphabet), a.as_string())
+        assert_eq!(alphabet, a.as_str())
     }
 }

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -1,7 +1,7 @@
 //! Provides [Alphabet] and constants for alphabets commonly used in the wild.
 
 use crate::PAD_BYTE;
-use core::{convert, fmt};
+use core::{convert, fmt, primitive::str};
 #[cfg(any(feature = "std", test))]
 use std::error;
 
@@ -126,7 +126,7 @@ impl Alphabet {
 
     /// Create a `&str` from the symbols in the `Alphabet`
     pub fn as_str(&self) -> &str {
-        std::str::from_utf8(&self.symbols).unwrap()
+        core::str::from_utf8(&self.symbols).unwrap()
     }
 }
 


### PR DESCRIPTION
This PR provides a method to return the characters in the `Alphabet` struct as a `String`. 

At present, there is no provided way to retrieve characters that were used to create the alphabet. One way to accomplish this today, is to capture the output of the `Debug` format and process it manually. This `as_string()` method will make it easier to do just that. Alternatively, if the `symbols` field of the struct was made public, the onus could be put on the users of the crate to iterate through the array and cast u8 as char.

As an alternative to a GH issue, I wanted to provide a PR instead. Please let me know if this suffices. 