### PR TITLE
Why 'Fit In' Provides Better Clarity in Technical Writing

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,7 +4,7 @@
 
 # 0.22.0
 
-- `DecodeSliceError::OutputSliceTooSmall` is now conservative rather than precise. That is, the error will only occur if the decoded output _cannot_ fit, meaning that `Engine::decode_slice` can now be used with exactly-sized output slices. As part of this, `Engine::internal_decode` now returns `DecodeSliceError` instead of `DecodeError`, but that is not expected to affect any external callers.
+- `DecodeSliceError::OutputSliceTooSmall` is now conservative rather than precise. That is, the error will only occur if the decoded output _cannot_ fit in, meaning that `Engine::decode_slice` can now be used with exactly-sized output slices. As part of this, `Engine::internal_decode` now returns `DecodeSliceError` instead of `DecodeError`, but that is not expected to affect any external callers.
 - `DecodeError::InvalidLength` now refers specifically to the _number of valid symbols_ being invalid (i.e. `len % 4 == 1`), rather than just the number of input bytes. This avoids confusing scenarios when based on interpretation you could make a case for either `InvalidLength` or `InvalidByte` being appropriate.
 - Decoding is somewhat faster (5-10%)
 


### PR DESCRIPTION
The phrase "cannot fit" is grammatically correct, but in English, "fit in" is considered more natural and precise when describing something that does not fit into a specific place. This adds context by specifying where the object is supposed to fit.

For example:
- "The data cannot fit" sounds like an incomplete thought: fit where?
- "The data cannot fit in the buffer" clearly states that the issue is related to the buffer size.

In programming contexts, where precision is critical, this clarification helps avoid ambiguity and makes the text more understandable for developers.
