### PR TITLE
Clarify the docs of `NO_PAD`, add shorthands for indifferent decoding.

### DIFF
--- a/src/engine/general_purpose/mod.rs
+++ b/src/engine/general_purpose/mod.rs
@@ -347,11 +347,21 @@ pub const URL_SAFE_NO_PAD: GeneralPurpose = GeneralPurpose::new(&alphabet::URL_S
 
 /// Include padding bytes when encoding, and require that they be present when decoding.
 ///
-/// This is the standard per the base64 RFC, but consider using [`NO_PAD`] instead as padding serves
+/// This is the standard per the base64 RFC, but consider using [`NO_PAD_INDIFFERENT`] instead as padding serves
 /// little purpose in practice.
 pub const PAD: GeneralPurposeConfig = GeneralPurposeConfig::new();
 
-/// Don't add padding when encoding, and require no padding when decoding.
+/// Include padding bytes when encoding, but allow input with or without padding when decoding.
+pub const PAD_INDIFFERENT: GeneralPurposeConfig = GeneralPurposeConfig::new()
+    .with_encode_padding(true)
+    .with_decode_padding_mode(DecodePaddingMode::Indifferent);
+
+/// Don't add padding when encoding, and require that there is no padding when decoding.
 pub const NO_PAD: GeneralPurposeConfig = GeneralPurposeConfig::new()
     .with_encode_padding(false)
     .with_decode_padding_mode(DecodePaddingMode::RequireNone);
+
+/// Don't add padding when encoding, and allow input with or without padding when decoding.
+pub const NO_PAD_INDIFFERENT: GeneralPurposeConfig = GeneralPurposeConfig::new()
+    .with_encode_padding(false)
+    .with_decode_padding_mode(DecodePaddingMode::Indifferent);


### PR DESCRIPTION
This PR tweaks the documentation of the `general_purpose::NO_PAD` configuration. The existing wording could be interpreted as "does not require padding when decoding" instead of "requires that there is no padding when decoding".

The PR also adds indifferent variants of the padding configs. I believe that in most applications, that is the correct behaviour: be strict in what you generate, be lenient in what you accept.

I didn't add any shorthands for the engines, as that would mean adding 4 new constants in total (`STANDARD_PAD_INDIFFERENT`, `STANDARD_NO_PAD_INDIFFERENT`, `URL_SAFE_PAD_INDIFFERENT` and `URL_SAFE_NO_PAD_INDIFFERENT`).

Personally, I would like to add those too, since I think `[NO_]PAD_INDIFFERENT` is most often the correct choice. However, I wanted to check here if adding those would be appreciated first.