### PR TITLE
Improve InvalidLastSymbol error

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,7 @@
 # Next
 
 - Added more consts for preconfigured configs and engines
+- Make DecodeError::InvalidLastSymbol more clear by including the decoded value
 
 # 0.22.1
 

--- a/src/read/decoder.rs
+++ b/src/read/decoder.rs
@@ -170,9 +170,15 @@ impl<'e, E: Engine, R: io::Read> DecoderReader<'e, E, R> {
                         DecodeError::InvalidLength(len) => {
                             DecodeError::InvalidLength(self.input_consumed_len + len)
                         }
-                        DecodeError::InvalidLastSymbol(offset, byte) => {
-                            DecodeError::InvalidLastSymbol(self.input_consumed_len + offset, byte)
-                        }
+                        DecodeError::InvalidLastSymbol {
+                            offset,
+                            symbol,
+                            symbol_value,
+                        } => DecodeError::InvalidLastSymbol {
+                            offset: self.input_consumed_len + offset,
+                            symbol,
+                            symbol_value,
+                        },
                         DecodeError::InvalidPadding => DecodeError::InvalidPadding,
                     }
                 }


### PR DESCRIPTION
Include the value the last symbol decoded to so that the `Debug` impl can provide more clarity about why it's invalid with the value's bit pattern. Hopefully this should quash the trickle of incorrect bug reports about failing to decode, but it probably won't...