### PR TITLE
Remove unnecessary clones on tests

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -403,7 +403,7 @@ mod coverage_gaming {
 
     #[test]
     fn decode_error() {
-        let _ = format!("{:?}", DecodeError::InvalidPadding.clone());
+        let _ = format!("{:?}", DecodeError::InvalidPadding);
         let _ = format!(
             "{} {} {} {}",
             DecodeError::InvalidByte(0, 0),
@@ -419,7 +419,7 @@ mod coverage_gaming {
 
     #[test]
     fn decode_slice_error() {
-        let _ = format!("{:?}", DecodeSliceError::OutputSliceTooSmall.clone());
+        let _ = format!("{:?}", DecodeSliceError::OutputSliceTooSmall);
         let _ = format!(
             "{} {}",
             DecodeSliceError::OutputSliceTooSmall,


### PR DESCRIPTION
As `.clone()` is being called on a fresh `DecodeError::InvalidPadding`, or `DecodeSliceError::OutputSliceTooSmall`, it can be safely removed.

CC @nunoplopes