### PR TITLE
feat: add SIMD acceleration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ rstest_reuse = "0.6.0"
 default = ["std"]
 alloc = []
 std = ["alloc"]
+# Enables the SIMD-accelerated engines (`Simd`, `Avx2`, `Neon`). Off by default. It is the only
+# feature that introduces `unsafe`; with it disabled the crate is `#![forbid(unsafe_code)]`.
+simd-unsafe = []
 
 [profile.bench]
 # Useful for better disassembly when using `perf record` and `perf annotate`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [base64](https://crates.io/crates/base64)
 
-[![](https://img.shields.io/crates/v/base64.svg)](https://crates.io/crates/base64) [![Docs](https://docs.rs/base64/badge.svg)](https://docs.rs/base64) [![CircleCI](https://circleci.com/gh/marshallpierce/rust-base64/tree/master.svg?style=shield)](https://circleci.com/gh/marshallpierce/rust-base64/tree/master) [![codecov](https://codecov.io/gh/marshallpierce/rust-base64/branch/master/graph/badge.svg)](https://codecov.io/gh/marshallpierce/rust-base64) [![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
+[![](https://img.shields.io/crates/v/base64.svg)](https://crates.io/crates/base64) [![Docs](https://docs.rs/base64/badge.svg)](https://docs.rs/base64) [![CircleCI](https://circleci.com/gh/marshallpierce/rust-base64/tree/master.svg?style=shield)](https://circleci.com/gh/marshallpierce/rust-base64/tree/master) [![codecov](https://codecov.io/gh/marshallpierce/rust-base64/branch/master/graph/badge.svg)](https://codecov.io/gh/marshallpierce/rust-base64)
 
 <a href="https://www.jetbrains.com/?from=rust-base64"><img src="/icon_CLion.svg" height="40px"/></a>
 
@@ -89,6 +89,17 @@ the `default-features` to target `core` instead. In that case you lose out on al
 around `std::io`, `std::error::Error`, and heap allocations. There is an additional `alloc` feature that you can activate
 to bring back the support for heap allocations.
 
+## SIMD acceleration
+
+The opt-in `simd-unsafe` feature enables SIMD-accelerated engines for the standard and
+URL-safe alphabets, which are several times faster than the scalar `GeneralPurpose` engine. It is
+the only feature that uses `unsafe`; without it the crate is `#![forbid(unsafe_code)]`.
+
+The `Simd` engine detects the best available instruction set (AVX2 on `x86_64`, NEON on `aarch64`) at
+runtime and falls back to the scalar engine, and needs the `std` feature. The `Avx2` and `Neon`
+engines target one instruction set without runtime detection, so they can be used in `no_std` builds
+when the target is known to support the instructions.
+
 ## Profiling
 
 On Linux, you can use [perf](https://perf.wiki.kernel.org/index.php/Main_Page) for profiling. Then compile the
@@ -151,4 +162,3 @@ cargo +nightly fuzz run decode_random
 ## License
 
 This project is dual-licensed under MIT and Apache 2.0.
-

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,6 +2,10 @@
 
 - Added more consts for preconfigured configs and engines
 - Make DecodeError::InvalidLastSymbol more clear by including the decoded value
+- Added SIMD-accelerated engines behind the opt-in `simd-unsafe` feature: `Simd` picks the best
+  instruction set at runtime (AVX2 on `x86_64`, NEON on `aarch64`) and falls back to the scalar
+  `GeneralPurpose` engine, while `Avx2` and `Neon` target one instruction set with no runtime
+  detection and work in `no_std`. The engines support the standard and URL-safe alphabets.
 
 # 0.22.1
 

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -99,6 +99,38 @@ fn do_encode_bench_slice(b: &mut Bencher, &size: &usize) {
     b.iter(|| STANDARD.encode_slice(&v, &mut buf).unwrap());
 }
 
+#[cfg(all(
+    feature = "simd-unsafe",
+    feature = "std",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
+fn do_encode_bench_slice_simd(b: &mut Bencher, &size: &usize) {
+    let engine = base64::engine::Simd::standard(base64::engine::general_purpose::PAD);
+    let mut v: Vec<u8> = Vec::with_capacity(size);
+    fill(&mut v);
+    // conservative estimate of encoded size
+    let mut buf = vec![0; v.len() * 2];
+    b.iter(|| engine.encode_slice(&v, &mut buf).unwrap());
+}
+
+#[cfg(all(
+    feature = "simd-unsafe",
+    feature = "std",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
+fn do_decode_bench_slice_simd(b: &mut Bencher, &size: &usize) {
+    let engine = base64::engine::Simd::standard(base64::engine::general_purpose::PAD);
+    let mut v: Vec<u8> = Vec::with_capacity(size * 3 / 4);
+    fill(&mut v);
+    let encoded = engine.encode(&v);
+
+    let mut buf = vec![0; size];
+    b.iter(|| {
+        engine.decode_slice(&encoded, &mut buf).unwrap();
+        black_box(&buf);
+    });
+}
+
 fn do_encode_bench_stream(b: &mut Bencher, &size: &usize) {
     let mut v: Vec<u8> = Vec::with_capacity(size);
     fill(&mut v);
@@ -193,6 +225,17 @@ fn encode_benchmarks(c: &mut Criterion, label: &str, byte_sizes: &[usize]) {
                 size,
                 do_encode_bench_string_reuse_buf_stream,
             );
+
+        #[cfg(all(
+            feature = "simd-unsafe",
+            feature = "std",
+            any(target_arch = "x86_64", target_arch = "aarch64")
+        ))]
+        group.bench_with_input(
+            BenchmarkId::new("encode_slice_simd", size),
+            size,
+            do_encode_bench_slice_simd,
+        );
     }
 
     group.finish();
@@ -222,6 +265,17 @@ fn decode_benchmarks(c: &mut Criterion, label: &str, byte_sizes: &[usize]) {
                 size,
                 do_decode_bench_stream,
             );
+
+        #[cfg(all(
+            feature = "simd-unsafe",
+            feature = "std",
+            any(target_arch = "x86_64", target_arch = "aarch64")
+        ))]
+        group.bench_with_input(
+            BenchmarkId::new("decode_slice_simd", size),
+            size,
+            do_decode_bench_slice_simd,
+        );
     }
 
     group.finish();

--- a/src/engine/general_purpose/decode.rs
+++ b/src/engine/general_purpose/decode.rs
@@ -39,27 +39,97 @@ pub(crate) fn decode_helper(
     decode_table: &[u8; 256],
     decode_allow_trailing_bits: bool,
     padding_mode: DecodePaddingMode,
+    simd_prefix: impl FnOnce(&[u8], usize, &mut [u8]) -> (usize, usize),
 ) -> Result<DecodeMetadata, DecodeSliceError> {
     let input_complete_nonterminal_quads_len =
         complete_quads_len(input, estimate.rem, output.len(), decode_table)?;
 
+    let output_complete_quad_len = input_complete_nonterminal_quads_len / 4 * 3;
+
+    // A SIMD backend, when applicable, decodes a leading prefix; the scalar loops decode the rest.
+    // `simd_prefix` returns `(input_consumed, output_written)` and must consume only whole, valid
+    // quads: `input_consumed % 4 == 0` and `<= input_complete_nonterminal_quads_len` (the terminal
+    // quad is left to `decode_suffix`), `output_written == input_consumed / 4 * 3`, and only those
+    // output bytes are written. It stops on the first invalid/ambiguous quad so the scalar decoder
+    // reports the precise error offset. `(0, 0)` (pure scalar) is always valid.
+    let (input_index, output_index) =
+        simd_prefix(input, input_complete_nonterminal_quads_len, output);
+
+    debug_assert!(input_index % 4 == 0, "prefix must consume whole quads");
+    debug_assert!(
+        input_index <= input_complete_nonterminal_quads_len,
+        "prefix must not consume the terminal quad"
+    );
+    debug_assert!(
+        output_index == input_index / 4 * 3,
+        "prefix output must match consumed input"
+    );
+    debug_assert!(
+        input_index <= input_complete_nonterminal_quads_len,
+        "prefix must not consume the terminal quad"
+    );
+    debug_assert!(
+        output_index == input_index / 4 * 3,
+        "prefix output must match consumed input"
+    );
+
+    decode_complete_quads(
+        input,
+        input_index,
+        input_complete_nonterminal_quads_len,
+        decode_table,
+        output,
+        output_index,
+    )?;
+
+    super::decode_suffix::decode_suffix(
+        input,
+        input_complete_nonterminal_quads_len,
+        output,
+        output_complete_quad_len,
+        decode_table,
+        decode_allow_trailing_bits,
+        padding_mode,
+    )
+}
+
+/// Decode the complete non-terminal quads in `input[input_index_start..input_index_end]` (both
+/// bounds multiples of 4), writing to `output` starting at `output_index_start`, which must equal
+/// `input_index_start / 4 * 3`. Error offsets are reported in absolute input coordinates.
+#[inline]
+fn decode_complete_quads(
+    input: &[u8],
+    input_index_start: usize,
+    input_index_end: usize,
+    decode_table: &[u8; 256],
+    output: &mut [u8],
+    output_index_start: usize,
+) -> Result<(), DecodeSliceError> {
+    debug_assert!(
+        input_index_start % 4 == 0,
+        "quad start must be quad-aligned"
+    );
+    debug_assert!(input_index_end % 4 == 0, "quad end must be quad-aligned");
+    debug_assert!(
+        output_index_start == input_index_start / 4 * 3,
+        "output start must match consumed input"
+    );
+
     const UNROLLED_INPUT_CHUNK_SIZE: usize = 32;
     const UNROLLED_OUTPUT_CHUNK_SIZE: usize = UNROLLED_INPUT_CHUNK_SIZE / 4 * 3;
 
-    let input_complete_quads_after_unrolled_chunks_len =
-        input_complete_nonterminal_quads_len % UNROLLED_INPUT_CHUNK_SIZE;
-
-    let input_unrolled_loop_len =
-        input_complete_nonterminal_quads_len - input_complete_quads_after_unrolled_chunks_len;
+    let quads_len = input_index_end - input_index_start;
+    let unrolled_loop_len = quads_len - quads_len % UNROLLED_INPUT_CHUNK_SIZE;
+    let input_unrolled_loop_end = input_index_start + unrolled_loop_len;
 
     // chunks of 32 bytes
-    for (chunk_index, chunk) in input[..input_unrolled_loop_len]
+    for (chunk_index, chunk) in input[input_index_start..input_unrolled_loop_end]
         .chunks_exact(UNROLLED_INPUT_CHUNK_SIZE)
         .enumerate()
     {
-        let input_index = chunk_index * UNROLLED_INPUT_CHUNK_SIZE;
-        let chunk_output = &mut output[chunk_index * UNROLLED_OUTPUT_CHUNK_SIZE
-            ..(chunk_index + 1) * UNROLLED_OUTPUT_CHUNK_SIZE];
+        let input_index = input_index_start + chunk_index * UNROLLED_INPUT_CHUNK_SIZE;
+        let output_base = output_index_start + chunk_index * UNROLLED_OUTPUT_CHUNK_SIZE;
+        let chunk_output = &mut output[output_base..output_base + UNROLLED_OUTPUT_CHUNK_SIZE];
 
         decode_chunk_8(
             &chunk[0..8],
@@ -88,36 +158,23 @@ pub(crate) fn decode_helper(
     }
 
     // remaining quads, except for the last possibly partial one, as it may have padding
-    let output_unrolled_loop_len = input_unrolled_loop_len / 4 * 3;
-    let output_complete_quad_len = input_complete_nonterminal_quads_len / 4 * 3;
+    let output_after_unroll_start = output_index_start + unrolled_loop_len / 4 * 3;
+    for (chunk_index, chunk) in input[input_unrolled_loop_end..input_index_end]
+        .chunks_exact(4)
+        .enumerate()
     {
-        let output_after_unroll = &mut output[output_unrolled_loop_len..output_complete_quad_len];
+        let output_base = output_after_unroll_start + chunk_index * 3;
+        let chunk_output = &mut output[output_base..output_base + 3];
 
-        for (chunk_index, chunk) in input
-            [input_unrolled_loop_len..input_complete_nonterminal_quads_len]
-            .chunks_exact(4)
-            .enumerate()
-        {
-            let chunk_output = &mut output_after_unroll[chunk_index * 3..chunk_index * 3 + 3];
-
-            decode_chunk_4(
-                chunk,
-                input_unrolled_loop_len + chunk_index * 4,
-                decode_table,
-                chunk_output,
-            )?;
-        }
+        decode_chunk_4(
+            chunk,
+            input_unrolled_loop_end + chunk_index * 4,
+            decode_table,
+            chunk_output,
+        )?;
     }
 
-    super::decode_suffix::decode_suffix(
-        input,
-        input_complete_nonterminal_quads_len,
-        output,
-        output_complete_quad_len,
-        decode_table,
-        decode_allow_trailing_bits,
-        padding_mode,
-    )
+    Ok(())
 }
 
 /// Returns the length of complete quads, except for the last one, even if it is complete.

--- a/src/engine/general_purpose/mod.rs
+++ b/src/engine/general_purpose/mod.rs
@@ -18,7 +18,8 @@ pub(crate) const INVALID_VALUE: u8 = 255;
 
 /// A general-purpose base64 engine.
 ///
-/// - It uses no vector CPU instructions, so it will work on any system.
+/// - It uses no vector CPU instructions, so it will work on any system. For a version that uses
+///   SIMD where available, see the SIMD engines behind the `simd-unsafe` feature.
 /// - It is reasonably fast (~2-3GiB/s).
 /// - It is not constant-time, though, so it is vulnerable to timing side-channel attacks. For loading cryptographic keys, etc, it is suggested to use the forthcoming constant-time implementation.
 
@@ -28,6 +29,12 @@ pub struct GeneralPurpose {
     decode_table: [u8; 256],
     config: GeneralPurposeConfig,
 }
+
+/// A purely scalar base64 engine that never uses hardware-specific vector instructions.
+///
+/// This is an alias for [`GeneralPurpose`], giving an explicit name for callers who want to
+/// guarantee a scalar-only implementation.
+pub type Scalar = GeneralPurpose;
 
 impl GeneralPurpose {
     /// Create a `GeneralPurpose` engine from an [Alphabet].
@@ -42,6 +49,30 @@ impl GeneralPurpose {
             config,
         }
     }
+
+    /// The 6-bit-index-to-ASCII encode table.
+    #[cfg(all(
+        feature = "simd-unsafe",
+        any(
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", target_feature = "neon")
+        )
+    ))]
+    pub(crate) fn encode_table(&self) -> &[u8; 64] {
+        &self.encode_table
+    }
+
+    /// The ASCII-to-6-bit-value decode table.
+    #[cfg(all(
+        feature = "simd-unsafe",
+        any(
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", target_feature = "neon")
+        )
+    ))]
+    pub(crate) fn decode_table(&self) -> &[u8; 256] {
+        &self.decode_table
+    }
 }
 
 impl super::Engine for GeneralPurpose {
@@ -49,122 +80,7 @@ impl super::Engine for GeneralPurpose {
     type DecodeEstimate = GeneralPurposeEstimate;
 
     fn internal_encode(&self, input: &[u8], output: &mut [u8]) -> usize {
-        let mut input_index: usize = 0;
-
-        const BLOCKS_PER_FAST_LOOP: usize = 4;
-        const LOW_SIX_BITS: u64 = 0x3F;
-
-        // we read 8 bytes at a time (u64) but only actually consume 6 of those bytes. Thus, we need
-        // 2 trailing bytes to be available to read..
-        let last_fast_index = input.len().saturating_sub(BLOCKS_PER_FAST_LOOP * 6 + 2);
-        let mut output_index = 0;
-
-        if last_fast_index > 0 {
-            while input_index <= last_fast_index {
-                // Major performance wins from letting the optimizer do the bounds check once, mostly
-                // on the output side
-                let input_chunk =
-                    &input[input_index..(input_index + (BLOCKS_PER_FAST_LOOP * 6 + 2))];
-                let output_chunk =
-                    &mut output[output_index..(output_index + BLOCKS_PER_FAST_LOOP * 8)];
-
-                // Hand-unrolling for 32 vs 16 or 8 bytes produces yields performance about equivalent
-                // to unsafe pointer code on a Xeon E5-1650v3. 64 byte unrolling was slightly better for
-                // large inputs but significantly worse for 50-byte input, unsurprisingly. I suspect
-                // that it's a not uncommon use case to encode smallish chunks of data (e.g. a 64-byte
-                // SHA-512 digest), so it would be nice if that fit in the unrolled loop at least once.
-                // Plus, single-digit percentage performance differences might well be quite different
-                // on different hardware.
-
-                let input_u64 = read_u64(&input_chunk[0..]);
-
-                output_chunk[0] = self.encode_table[((input_u64 >> 58) & LOW_SIX_BITS) as usize];
-                output_chunk[1] = self.encode_table[((input_u64 >> 52) & LOW_SIX_BITS) as usize];
-                output_chunk[2] = self.encode_table[((input_u64 >> 46) & LOW_SIX_BITS) as usize];
-                output_chunk[3] = self.encode_table[((input_u64 >> 40) & LOW_SIX_BITS) as usize];
-                output_chunk[4] = self.encode_table[((input_u64 >> 34) & LOW_SIX_BITS) as usize];
-                output_chunk[5] = self.encode_table[((input_u64 >> 28) & LOW_SIX_BITS) as usize];
-                output_chunk[6] = self.encode_table[((input_u64 >> 22) & LOW_SIX_BITS) as usize];
-                output_chunk[7] = self.encode_table[((input_u64 >> 16) & LOW_SIX_BITS) as usize];
-
-                let input_u64 = read_u64(&input_chunk[6..]);
-
-                output_chunk[8] = self.encode_table[((input_u64 >> 58) & LOW_SIX_BITS) as usize];
-                output_chunk[9] = self.encode_table[((input_u64 >> 52) & LOW_SIX_BITS) as usize];
-                output_chunk[10] = self.encode_table[((input_u64 >> 46) & LOW_SIX_BITS) as usize];
-                output_chunk[11] = self.encode_table[((input_u64 >> 40) & LOW_SIX_BITS) as usize];
-                output_chunk[12] = self.encode_table[((input_u64 >> 34) & LOW_SIX_BITS) as usize];
-                output_chunk[13] = self.encode_table[((input_u64 >> 28) & LOW_SIX_BITS) as usize];
-                output_chunk[14] = self.encode_table[((input_u64 >> 22) & LOW_SIX_BITS) as usize];
-                output_chunk[15] = self.encode_table[((input_u64 >> 16) & LOW_SIX_BITS) as usize];
-
-                let input_u64 = read_u64(&input_chunk[12..]);
-
-                output_chunk[16] = self.encode_table[((input_u64 >> 58) & LOW_SIX_BITS) as usize];
-                output_chunk[17] = self.encode_table[((input_u64 >> 52) & LOW_SIX_BITS) as usize];
-                output_chunk[18] = self.encode_table[((input_u64 >> 46) & LOW_SIX_BITS) as usize];
-                output_chunk[19] = self.encode_table[((input_u64 >> 40) & LOW_SIX_BITS) as usize];
-                output_chunk[20] = self.encode_table[((input_u64 >> 34) & LOW_SIX_BITS) as usize];
-                output_chunk[21] = self.encode_table[((input_u64 >> 28) & LOW_SIX_BITS) as usize];
-                output_chunk[22] = self.encode_table[((input_u64 >> 22) & LOW_SIX_BITS) as usize];
-                output_chunk[23] = self.encode_table[((input_u64 >> 16) & LOW_SIX_BITS) as usize];
-
-                let input_u64 = read_u64(&input_chunk[18..]);
-
-                output_chunk[24] = self.encode_table[((input_u64 >> 58) & LOW_SIX_BITS) as usize];
-                output_chunk[25] = self.encode_table[((input_u64 >> 52) & LOW_SIX_BITS) as usize];
-                output_chunk[26] = self.encode_table[((input_u64 >> 46) & LOW_SIX_BITS) as usize];
-                output_chunk[27] = self.encode_table[((input_u64 >> 40) & LOW_SIX_BITS) as usize];
-                output_chunk[28] = self.encode_table[((input_u64 >> 34) & LOW_SIX_BITS) as usize];
-                output_chunk[29] = self.encode_table[((input_u64 >> 28) & LOW_SIX_BITS) as usize];
-                output_chunk[30] = self.encode_table[((input_u64 >> 22) & LOW_SIX_BITS) as usize];
-                output_chunk[31] = self.encode_table[((input_u64 >> 16) & LOW_SIX_BITS) as usize];
-
-                output_index += BLOCKS_PER_FAST_LOOP * 8;
-                input_index += BLOCKS_PER_FAST_LOOP * 6;
-            }
-        }
-
-        // Encode what's left after the fast loop.
-
-        const LOW_SIX_BITS_U8: u8 = 0x3F;
-
-        let rem = input.len() % 3;
-        let start_of_rem = input.len() - rem;
-
-        // start at the first index not handled by fast loop, which may be 0.
-
-        while input_index < start_of_rem {
-            let input_chunk = &input[input_index..(input_index + 3)];
-            let output_chunk = &mut output[output_index..(output_index + 4)];
-
-            output_chunk[0] = self.encode_table[(input_chunk[0] >> 2) as usize];
-            output_chunk[1] = self.encode_table
-                [((input_chunk[0] << 4 | input_chunk[1] >> 4) & LOW_SIX_BITS_U8) as usize];
-            output_chunk[2] = self.encode_table
-                [((input_chunk[1] << 2 | input_chunk[2] >> 6) & LOW_SIX_BITS_U8) as usize];
-            output_chunk[3] = self.encode_table[(input_chunk[2] & LOW_SIX_BITS_U8) as usize];
-
-            input_index += 3;
-            output_index += 4;
-        }
-
-        if rem == 2 {
-            output[output_index] = self.encode_table[(input[start_of_rem] >> 2) as usize];
-            output[output_index + 1] =
-                self.encode_table[((input[start_of_rem] << 4 | input[start_of_rem + 1] >> 4)
-                    & LOW_SIX_BITS_U8) as usize];
-            output[output_index + 2] =
-                self.encode_table[((input[start_of_rem + 1] << 2) & LOW_SIX_BITS_U8) as usize];
-            output_index += 3;
-        } else if rem == 1 {
-            output[output_index] = self.encode_table[(input[start_of_rem] >> 2) as usize];
-            output[output_index + 1] =
-                self.encode_table[((input[start_of_rem] << 4) & LOW_SIX_BITS_U8) as usize];
-            output_index += 2;
-        }
-
-        output_index
+        encode_helper(&self.encode_table, input, output, |_, _| (0, 0))
     }
 
     fn internal_decoded_len_estimate(&self, input_len: usize) -> Self::DecodeEstimate {
@@ -184,12 +100,164 @@ impl super::Engine for GeneralPurpose {
             &self.decode_table,
             self.config.decode_allow_trailing_bits,
             self.config.decode_padding_mode,
+            |_, _, _| (0, 0),
         )
     }
 
     fn config(&self) -> &Self::Config {
         &self.config
     }
+}
+
+/// Scalar base64 encode of `input` into `output`, returning the number of bytes written.
+///
+/// `simd_prefix` gets first crack at the input, returning `(input_consumed, output_written)`. It
+/// must consume whole 3-byte groups: `input_consumed % 3 == 0`, `output_written == input_consumed /
+/// 3 * 4`, both in bounds, and only those `output_written` bytes are written. `(0, 0)` (pure scalar)
+/// is always valid.
+#[inline]
+pub(crate) fn encode_helper(
+    encode_table: &[u8; 64],
+    input: &[u8],
+    output: &mut [u8],
+    simd_prefix: impl FnOnce(&[u8], &mut [u8]) -> (usize, usize),
+) -> usize {
+    let (input_index, output_index) = simd_prefix(input, output);
+
+    debug_assert!(
+        input_index % 3 == 0,
+        "prefix must consume whole 3-byte groups"
+    );
+    debug_assert!(
+        output_index == input_index / 3 * 4,
+        "prefix output must match consumed input"
+    );
+    debug_assert!(input_index <= input.len());
+    debug_assert!(output_index <= output.len());
+
+    encode_scalar_tail(encode_table, input, output, input_index, output_index)
+}
+
+/// Scalar encode of `input[input_index..]` into `output[output_index..]`, resuming from a 3-byte
+/// group boundary. Returns the total number of output bytes written.
+fn encode_scalar_tail(
+    encode_table: &[u8; 64],
+    input: &[u8],
+    output: &mut [u8],
+    mut input_index: usize,
+    mut output_index: usize,
+) -> usize {
+    const BLOCKS_PER_FAST_LOOP: usize = 4;
+    const LOW_SIX_BITS: u64 = 0x3F;
+
+    // we read 8 bytes at a time (u64) but only actually consume 6 of those bytes. Thus, we need
+    // 2 trailing bytes to be available to read..
+    let last_fast_index = input.len().saturating_sub(BLOCKS_PER_FAST_LOOP * 6 + 2);
+
+    if last_fast_index > 0 {
+        while input_index <= last_fast_index {
+            // Major performance wins from letting the optimizer do the bounds check once, mostly
+            // on the output side
+            let input_chunk = &input[input_index..(input_index + (BLOCKS_PER_FAST_LOOP * 6 + 2))];
+            let output_chunk = &mut output[output_index..(output_index + BLOCKS_PER_FAST_LOOP * 8)];
+
+            // Hand-unrolling for 32 vs 16 or 8 bytes produces yields performance about equivalent
+            // to unsafe pointer code on a Xeon E5-1650v3. 64 byte unrolling was slightly better for
+            // large inputs but significantly worse for 50-byte input, unsurprisingly. I suspect
+            // that it's a not uncommon use case to encode smallish chunks of data (e.g. a 64-byte
+            // SHA-512 digest), so it would be nice if that fit in the unrolled loop at least once.
+            // Plus, single-digit percentage performance differences might well be quite different
+            // on different hardware.
+
+            let input_u64 = read_u64(&input_chunk[0..]);
+
+            output_chunk[0] = encode_table[((input_u64 >> 58) & LOW_SIX_BITS) as usize];
+            output_chunk[1] = encode_table[((input_u64 >> 52) & LOW_SIX_BITS) as usize];
+            output_chunk[2] = encode_table[((input_u64 >> 46) & LOW_SIX_BITS) as usize];
+            output_chunk[3] = encode_table[((input_u64 >> 40) & LOW_SIX_BITS) as usize];
+            output_chunk[4] = encode_table[((input_u64 >> 34) & LOW_SIX_BITS) as usize];
+            output_chunk[5] = encode_table[((input_u64 >> 28) & LOW_SIX_BITS) as usize];
+            output_chunk[6] = encode_table[((input_u64 >> 22) & LOW_SIX_BITS) as usize];
+            output_chunk[7] = encode_table[((input_u64 >> 16) & LOW_SIX_BITS) as usize];
+
+            let input_u64 = read_u64(&input_chunk[6..]);
+
+            output_chunk[8] = encode_table[((input_u64 >> 58) & LOW_SIX_BITS) as usize];
+            output_chunk[9] = encode_table[((input_u64 >> 52) & LOW_SIX_BITS) as usize];
+            output_chunk[10] = encode_table[((input_u64 >> 46) & LOW_SIX_BITS) as usize];
+            output_chunk[11] = encode_table[((input_u64 >> 40) & LOW_SIX_BITS) as usize];
+            output_chunk[12] = encode_table[((input_u64 >> 34) & LOW_SIX_BITS) as usize];
+            output_chunk[13] = encode_table[((input_u64 >> 28) & LOW_SIX_BITS) as usize];
+            output_chunk[14] = encode_table[((input_u64 >> 22) & LOW_SIX_BITS) as usize];
+            output_chunk[15] = encode_table[((input_u64 >> 16) & LOW_SIX_BITS) as usize];
+
+            let input_u64 = read_u64(&input_chunk[12..]);
+
+            output_chunk[16] = encode_table[((input_u64 >> 58) & LOW_SIX_BITS) as usize];
+            output_chunk[17] = encode_table[((input_u64 >> 52) & LOW_SIX_BITS) as usize];
+            output_chunk[18] = encode_table[((input_u64 >> 46) & LOW_SIX_BITS) as usize];
+            output_chunk[19] = encode_table[((input_u64 >> 40) & LOW_SIX_BITS) as usize];
+            output_chunk[20] = encode_table[((input_u64 >> 34) & LOW_SIX_BITS) as usize];
+            output_chunk[21] = encode_table[((input_u64 >> 28) & LOW_SIX_BITS) as usize];
+            output_chunk[22] = encode_table[((input_u64 >> 22) & LOW_SIX_BITS) as usize];
+            output_chunk[23] = encode_table[((input_u64 >> 16) & LOW_SIX_BITS) as usize];
+
+            let input_u64 = read_u64(&input_chunk[18..]);
+
+            output_chunk[24] = encode_table[((input_u64 >> 58) & LOW_SIX_BITS) as usize];
+            output_chunk[25] = encode_table[((input_u64 >> 52) & LOW_SIX_BITS) as usize];
+            output_chunk[26] = encode_table[((input_u64 >> 46) & LOW_SIX_BITS) as usize];
+            output_chunk[27] = encode_table[((input_u64 >> 40) & LOW_SIX_BITS) as usize];
+            output_chunk[28] = encode_table[((input_u64 >> 34) & LOW_SIX_BITS) as usize];
+            output_chunk[29] = encode_table[((input_u64 >> 28) & LOW_SIX_BITS) as usize];
+            output_chunk[30] = encode_table[((input_u64 >> 22) & LOW_SIX_BITS) as usize];
+            output_chunk[31] = encode_table[((input_u64 >> 16) & LOW_SIX_BITS) as usize];
+
+            output_index += BLOCKS_PER_FAST_LOOP * 8;
+            input_index += BLOCKS_PER_FAST_LOOP * 6;
+        }
+    }
+
+    // Encode what's left after the fast loop.
+
+    const LOW_SIX_BITS_U8: u8 = 0x3F;
+
+    let rem = input.len() % 3;
+    let start_of_rem = input.len() - rem;
+
+    // start at the first index not handled by fast loop, which may be 0.
+
+    while input_index < start_of_rem {
+        let input_chunk = &input[input_index..(input_index + 3)];
+        let output_chunk = &mut output[output_index..(output_index + 4)];
+
+        output_chunk[0] = encode_table[(input_chunk[0] >> 2) as usize];
+        output_chunk[1] =
+            encode_table[((input_chunk[0] << 4 | input_chunk[1] >> 4) & LOW_SIX_BITS_U8) as usize];
+        output_chunk[2] =
+            encode_table[((input_chunk[1] << 2 | input_chunk[2] >> 6) & LOW_SIX_BITS_U8) as usize];
+        output_chunk[3] = encode_table[(input_chunk[2] & LOW_SIX_BITS_U8) as usize];
+
+        input_index += 3;
+        output_index += 4;
+    }
+
+    if rem == 2 {
+        output[output_index] = encode_table[(input[start_of_rem] >> 2) as usize];
+        output[output_index + 1] = encode_table[((input[start_of_rem] << 4
+            | input[start_of_rem + 1] >> 4)
+            & LOW_SIX_BITS_U8) as usize];
+        output[output_index + 2] =
+            encode_table[((input[start_of_rem + 1] << 2) & LOW_SIX_BITS_U8) as usize];
+        output_index += 3;
+    } else if rem == 1 {
+        output[output_index] = encode_table[(input[start_of_rem] >> 2) as usize];
+        output[output_index + 1] =
+            encode_table[((input[start_of_rem] << 4) & LOW_SIX_BITS_U8) as usize];
+        output_index += 2;
+    }
+
+    output_index
 }
 
 /// Returns a table mapping a 6-bit index to the ASCII byte encoding of the index
@@ -332,6 +400,25 @@ impl Default for GeneralPurposeConfig {
 impl Config for GeneralPurposeConfig {
     fn encode_padding(&self) -> bool {
         self.encode_padding
+    }
+}
+
+#[cfg(all(
+    feature = "simd-unsafe",
+    any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", target_feature = "neon")
+    )
+))]
+impl GeneralPurposeConfig {
+    /// Whether trailing bits are allowed when decoding.
+    pub(crate) fn decode_allow_trailing_bits(&self) -> bool {
+        self.decode_allow_trailing_bits
+    }
+
+    /// The decode padding mode.
+    pub(crate) fn decode_padding_mode(&self) -> DecodePaddingMode {
+        self.decode_padding_mode
     }
 }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -13,13 +13,45 @@ use alloc::{string::String, vec};
 
 pub mod general_purpose;
 
+#[cfg(all(
+    feature = "simd-unsafe",
+    any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", target_feature = "neon")
+    )
+))]
+pub mod simd;
+
 #[cfg(test)]
 mod naive;
 
 #[cfg(test)]
 mod tests;
 
-pub use general_purpose::{GeneralPurpose, GeneralPurposeConfig};
+pub use general_purpose::{GeneralPurpose, GeneralPurposeConfig, Scalar};
+
+/// The runtime-detected SIMD engine. Requires the `simd-unsafe` feature.
+#[cfg(all(
+    feature = "simd-unsafe",
+    feature = "std",
+    any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", target_feature = "neon")
+    )
+))]
+pub use simd::Simd;
+
+/// The AVX2 engine. Requires the `simd-unsafe` feature on an `x86_64` target.
+#[cfg(all(feature = "simd-unsafe", target_arch = "x86_64"))]
+pub use simd::Avx2;
+
+/// The NEON engine. Requires the `simd-unsafe` feature on an `aarch64` target.
+#[cfg(all(
+    feature = "simd-unsafe",
+    target_arch = "aarch64",
+    target_feature = "neon"
+))]
+pub use simd::Neon;
 
 /// An `Engine` provides low-level encoding and decoding operations that all other higher-level parts of the API use. Users of the library will generally not need to implement this.
 ///

--- a/src/engine/simd.rs
+++ b/src/engine/simd.rs
@@ -1,0 +1,899 @@
+//! SIMD-accelerated engines for the standard and URL-safe alphabets.
+//!
+//! These are gated behind the `simd-unsafe` feature because they use `unsafe`. Three engines are
+//! provided:
+//!
+//! - `Simd` detects the best available instruction set at runtime and falls back to the scalar
+//!   [`GeneralPurpose`] engine when none is available. It requires `std` for the detection.
+//! - `Avx2` and `Neon` target a specific instruction set with no runtime detection, so they can
+//!   be used in `no_std` builds when the target is known to support the instructions.
+//!
+//! Only the STANDARD and URL_SAFE alphabets are accelerated (they share indices `0..=61` and differ
+//! only at `62`/`63`). Each engine therefore has dedicated `standard` / `url_safe` constructors
+//! rather than taking an arbitrary [`Alphabet`](crate::alphabet::Alphabet); use [`GeneralPurpose`]
+//! for any other alphabet.
+//!
+//! The kernels follow Wojciech Mula's vectorized base64 algorithms
+//! (<http://0x80.pl/notesen/2016-01-17-sse-base64-decoding.html> and the companion encoding note).
+//! AVX2 uses the multiply-based bit (de)interleave; NEON, which lacks the relevant multiplies, uses
+//! the shift/mask variant. Both share the same per-alphabet lookup tables, expressed as the
+//! associated constants of the `SimdAlphabet` trait so the kernels can inline them.
+#![allow(unsafe_code)]
+// NEON intrinsics require Rust 1.59, above the crate MSRV; these paths need `std`/the feature and
+// are not built at MSRV.
+#![allow(clippy::incompatible_msrv)]
+
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+use crate::{
+    engine::{
+        general_purpose::{
+            decode::decode_helper, encode_helper, GeneralPurpose, GeneralPurposeConfig,
+            GeneralPurposeEstimate,
+        },
+        DecodeMetadata, Engine,
+    },
+    DecodeSliceError,
+};
+
+/// A base64 alphabet family the SIMD kernels can accelerate.
+///
+/// Carries the per-alphabet lookup tables as associated constants. Private (hence sealed);
+/// implemented only by [`Standard`] and [`UrlSafe`], selected at runtime by [`SimdKind`].
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+trait SimdAlphabet {
+    /// pshufb encode table: maps a reduced 6-bit index to `ascii - index`.
+    const ENCODE_LUT: [i8; 16];
+    /// pshufb decode table indexed by the high nibble; added to the byte to produce its 6-bit value.
+    const DECODE_SHIFT_LUT: [i8; 16];
+    /// pshufb decode table indexed by the low nibble; bit `hi` marks `(hi, lo)` as a valid symbol.
+    const DECODE_MASK_LUT: [u8; 16];
+    /// The high-`62`/`63` symbol whose shift needs the fixup below (`+`/`-`).
+    const DECODE_FIXUP_CHAR: i8;
+    /// The shift applied to [`DECODE_FIXUP_CHAR`](Self::DECODE_FIXUP_CHAR).
+    const DECODE_FIXUP_SHIFT: i8;
+}
+
+/// The STANDARD alphabet family (`+`/`/` at 62/63).
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+enum Standard {}
+
+/// The URL_SAFE alphabet family (`-`/`_` at 62/63).
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+enum UrlSafe {}
+
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+impl SimdAlphabet for Standard {
+    const ENCODE_LUT: [i8; 16] = [
+        65, 71, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -19, -16, 0, 0,
+    ];
+    const DECODE_SHIFT_LUT: [i8; 16] = [0, 0, 19, 4, -65, -65, -71, -71, 0, 0, 0, 0, 0, 0, 0, 0];
+    const DECODE_MASK_LUT: [u8; 16] = [
+        0xA8, 0xF8, 0xF8, 0xF8, 0xF8, 0xF8, 0xF8, 0xF8, 0xF8, 0xF8, 0xF0, 0x54, 0x50, 0x50, 0x50,
+        0x54,
+    ];
+    const DECODE_FIXUP_CHAR: i8 = 0x2F;
+    const DECODE_FIXUP_SHIFT: i8 = 16;
+}
+
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+impl SimdAlphabet for UrlSafe {
+    const ENCODE_LUT: [i8; 16] = [
+        65, 71, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -17, 32, 0, 0,
+    ];
+    const DECODE_SHIFT_LUT: [i8; 16] = [0, 0, 17, 4, -65, -65, -71, -71, 0, 0, 0, 0, 0, 0, 0, 0];
+    const DECODE_MASK_LUT: [u8; 16] = [
+        0xA8, 0xF8, 0xF8, 0xF8, 0xF8, 0xF8, 0xF8, 0xF8, 0xF8, 0xF8, 0xF0, 0x50, 0x50, 0x54, 0x50,
+        0x70,
+    ];
+    const DECODE_FIXUP_CHAR: i8 = 0x5F;
+    const DECODE_FIXUP_SHIFT: i8 = -32;
+}
+
+/// Which accelerated alphabet family an engine uses. Selects the kernel monomorphization at runtime.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SimdKind {
+    Standard,
+    UrlSafe,
+}
+
+/// Minimum input length before a SIMD path is used. Below these the setup cost outweighs the gain;
+/// encode needs more data than decode to break even.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+const SIMD_MIN_INPUT_ENCODE: usize = 128;
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+const SIMD_MIN_INPUT_DECODE: usize = 64;
+
+/// pshufb decode validity table: maps a high nibble to a single set bit. Shared by both alphabets.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+const BITPOS_LUT: [u8; 16] = [1, 2, 4, 8, 16, 32, 64, 128, 0, 0, 0, 0, 0, 0, 0, 0];
+
+#[cfg(target_arch = "x86_64")]
+mod avx2 {
+    use super::{SimdAlphabet, BITPOS_LUT, SIMD_MIN_INPUT_DECODE, SIMD_MIN_INPUT_ENCODE};
+    use core::arch::x86_64::*;
+
+    /// Encode leading whole 24-byte input groups (24 in -> 32 out per iteration).
+    ///
+    /// # Safety
+    ///
+    /// The running CPU must support AVX2.
+    #[target_feature(enable = "avx2")]
+    pub(super) unsafe fn encode_bulk<A: SimdAlphabet>(
+        input: &[u8],
+        output: &mut [u8],
+    ) -> (usize, usize) {
+        if input.len() < SIMD_MIN_INPUT_ENCODE {
+            return (0, 0);
+        }
+        let lut_data = A::ENCODE_LUT;
+        // SAFETY: `lut_data` is a 16-byte array; `_mm_loadu_si128` reads exactly 16 bytes from it.
+        let lut = _mm256_broadcastsi128_si256(_mm_loadu_si128(lut_data.as_ptr().cast()));
+        #[rustfmt::skip]
+        let shuf = _mm256_setr_epi8(
+            1, 0, 2, 1, 4, 3, 5, 4, 7, 6, 8, 7, 10, 9, 11, 10,
+            1, 0, 2, 1, 4, 3, 5, 4, 7, 6, 8, 7, 10, 9, 11, 10,
+        );
+        let mask_hi = _mm256_set1_epi32(0x0fc0_fc00_u32 as i32);
+        let mul_hi = _mm256_set1_epi32(0x0400_0040);
+        let mask_lo = _mm256_set1_epi32(0x003f_03f0);
+        let mul_lo = _mm256_set1_epi32(0x0100_0010);
+        let const51 = _mm256_set1_epi8(51);
+        let const25 = _mm256_set1_epi8(25);
+
+        let mut i = 0usize;
+        let mut o = 0usize;
+        // A whole 32-byte vector is read but only 24 bytes are consumed, so 32 input bytes must be
+        // available; the store writes 32 output bytes.
+        while i + 32 <= input.len() && o + 32 <= output.len() {
+            // SAFETY: the loop guard ensures `input[i..i+32]` is in bounds, so this reads 32 valid
+            // bytes; `loadu` has no alignment requirement.
+            let data = _mm256_loadu_si256(input.as_ptr().add(i).cast());
+            // Rearrange dwords so low lane = bytes[0..16], high lane = bytes[12..28].
+            let perm = _mm256_permutevar8x32_epi32(data, _mm256_setr_epi32(0, 1, 2, 3, 3, 4, 5, 6));
+            let inb = _mm256_shuffle_epi8(perm, shuf);
+
+            let t0 = _mm256_and_si256(inb, mask_hi);
+            let t1 = _mm256_mulhi_epu16(t0, mul_hi);
+            let t2 = _mm256_and_si256(inb, mask_lo);
+            let t3 = _mm256_mullo_epi16(t2, mul_lo);
+            let indices = _mm256_or_si256(t1, t3); // one 6-bit value (0..=63) per byte
+
+            let reduced = _mm256_subs_epu8(indices, const51);
+            let gt25 = _mm256_cmpgt_epi8(indices, const25);
+            let reduced = _mm256_sub_epi8(reduced, gt25);
+            let ascii = _mm256_add_epi8(indices, _mm256_shuffle_epi8(lut, reduced));
+
+            // SAFETY: the loop guard ensures `output[o..o+32]` is in bounds; `storeu` writes 32
+            // bytes with no alignment requirement.
+            _mm256_storeu_si256(output.as_mut_ptr().add(o).cast(), ascii);
+            i += 24;
+            o += 32;
+        }
+        (i, o)
+    }
+
+    /// Decode leading whole 32-byte input blocks (32 in -> 24 out per iteration).
+    ///
+    /// # Safety
+    ///
+    /// The running CPU must support AVX2.
+    #[target_feature(enable = "avx2")]
+    pub(super) unsafe fn decode_bulk<A: SimdAlphabet>(
+        input: &[u8],
+        quads_end: usize,
+        output: &mut [u8],
+    ) -> (usize, usize) {
+        if quads_end < SIMD_MIN_INPUT_DECODE {
+            return (0, 0);
+        }
+        let shift_data = A::DECODE_SHIFT_LUT;
+        let mask_data = A::DECODE_MASK_LUT;
+        // SAFETY: each LUT is a 16-byte array read in full by `_mm_loadu_si128`.
+        let shift_lut = _mm256_broadcastsi128_si256(_mm_loadu_si128(shift_data.as_ptr().cast()));
+        let mask_lut = _mm256_broadcastsi128_si256(_mm_loadu_si128(mask_data.as_ptr().cast()));
+        let bitpos_lut = _mm256_broadcastsi128_si256(_mm_loadu_si128(BITPOS_LUT.as_ptr().cast()));
+        let low_nibble_mask = _mm256_set1_epi8(0x0f);
+        let fixup_char = _mm256_set1_epi8(A::DECODE_FIXUP_CHAR);
+        let fixup_shift = _mm256_set1_epi8(A::DECODE_FIXUP_SHIFT);
+        let zero = _mm256_setzero_si256();
+        let merge_mul1 = _mm256_set1_epi32(0x0140_0140);
+        let merge_mul2 = _mm256_set1_epi32(0x0001_1000);
+        #[rustfmt::skip]
+        let pack_shuf = _mm256_setr_epi8(
+            2, 1, 0, 6, 5, 4, 10, 9, 8, 14, 13, 12, -1, -1, -1, -1,
+            2, 1, 0, 6, 5, 4, 10, 9, 8, 14, 13, 12, -1, -1, -1, -1,
+        );
+        let lane_compact = _mm256_setr_epi32(0, 1, 2, 4, 5, 6, 6, 6);
+
+        let mut i = 0usize;
+        let mut o = 0usize;
+        // Need 32 input bytes available to load; the store writes exactly 24 output bytes.
+        while i + 32 <= quads_end && o + 24 <= output.len() {
+            // SAFETY: `i + 32 <= quads_end <= input.len()`, so this reads 32 in-bounds bytes;
+            // `loadu` needs no alignment.
+            let data = _mm256_loadu_si256(input.as_ptr().add(i).cast());
+
+            let hi_nibbles = _mm256_and_si256(_mm256_srli_epi32(data, 4), low_nibble_mask);
+            let lo_nibbles = _mm256_and_si256(data, low_nibble_mask);
+
+            let m = _mm256_shuffle_epi8(mask_lut, lo_nibbles);
+            let bit = _mm256_shuffle_epi8(bitpos_lut, hi_nibbles);
+            let non_match = _mm256_cmpeq_epi8(_mm256_and_si256(m, bit), zero);
+            if _mm256_movemask_epi8(non_match) != 0 {
+                // Invalid byte in this block; let the scalar decoder report the exact offset.
+                break;
+            }
+
+            let sh = _mm256_shuffle_epi8(shift_lut, hi_nibbles);
+            let eq_fixup = _mm256_cmpeq_epi8(data, fixup_char);
+            let shift = _mm256_blendv_epi8(sh, fixup_shift, eq_fixup);
+            let values = _mm256_add_epi8(data, shift); // 6-bit value per byte
+
+            let merged = _mm256_maddubs_epi16(values, merge_mul1);
+            let packed = _mm256_madd_epi16(merged, merge_mul2);
+            let shuffled = _mm256_shuffle_epi8(packed, pack_shuf);
+            let compact = _mm256_permutevar8x32_epi32(shuffled, lane_compact);
+
+            // Store exactly 24 bytes (16 + 8); a wider store would clobber an oversized output.
+            let lo = _mm256_castsi256_si128(compact);
+            let hi = _mm256_extracti128_si256(compact, 1);
+            // SAFETY: the loop guard ensures `o + 24 <= output.len()`, so the 16-byte store at `o`
+            // and the 8-byte store at `o + 16` are both in bounds; neither needs alignment.
+            _mm_storeu_si128(output.as_mut_ptr().add(o).cast(), lo);
+            _mm_storel_epi64(output.as_mut_ptr().add(o + 16).cast(), hi);
+            i += 32;
+            o += 24;
+        }
+        (i, o)
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+mod neon {
+    use super::{SimdAlphabet, BITPOS_LUT, SIMD_MIN_INPUT_DECODE, SIMD_MIN_INPUT_ENCODE};
+    use core::arch::aarch64::*;
+
+    /// Encode leading whole 12-byte input groups (12 in -> 16 out per iteration).
+    ///
+    /// # Safety
+    ///
+    /// The running CPU must support NEON.
+    #[target_feature(enable = "neon")]
+    pub(super) unsafe fn encode_bulk<A: SimdAlphabet>(
+        input: &[u8],
+        output: &mut [u8],
+    ) -> (usize, usize) {
+        if input.len() < SIMD_MIN_INPUT_ENCODE {
+            return (0, 0);
+        }
+        let lut_data = A::ENCODE_LUT;
+        let split_bytes: [u8; 16] = [1, 0, 2, 1, 4, 3, 5, 4, 7, 6, 8, 7, 10, 9, 11, 10];
+        // SAFETY: `split_bytes` and `lut_data` are 16-byte arrays, each read in full by `vld1q_u8`.
+        let split_shuf = vld1q_u8(split_bytes.as_ptr());
+        let translate = vld1q_u8(lut_data.as_ptr().cast());
+        let m1 = vdupq_n_u32(0x0000_fc00);
+        let m2 = vdupq_n_u32(0x0000_03f0);
+        let m3 = vdupq_n_u32(0x0fc0_0000);
+        let m4 = vdupq_n_u32(0x003f_0000);
+        let c51 = vdupq_n_u8(51);
+        let c25 = vdupq_n_s8(25);
+
+        let mut i = 0usize;
+        let mut o = 0usize;
+        // Reads a full 16-byte vector but consumes only 12 bytes, so 16 must be readable; writes
+        // exactly 16 output bytes.
+        while i + 16 <= input.len() && o + 16 <= output.len() {
+            // SAFETY: the loop guard ensures `input[i..i+16]` is in bounds, so this reads 16 valid
+            // bytes.
+            let data = vld1q_u8(input.as_ptr().add(i));
+            let x0 = vreinterpretq_u32_u8(vqtbl1q_u8(data, split_shuf));
+
+            let x1 = vshrq_n_u16::<10>(vreinterpretq_u16_u32(vandq_u32(x0, m1)));
+            let x2 = vshlq_n_u16::<4>(vreinterpretq_u16_u32(vandq_u32(x0, m2)));
+            let x3 = vshrq_n_u16::<6>(vreinterpretq_u16_u32(vandq_u32(x0, m3)));
+            let x4 = vshlq_n_u16::<8>(vreinterpretq_u16_u32(vandq_u32(x0, m4)));
+            let indices = vreinterpretq_u8_u16(vorrq_u16(vorrq_u16(x1, x2), vorrq_u16(x3, x4)));
+
+            // reduce the 6-bit index to a translate-LUT index, then add the offset to get ascii
+            let reduced = vqsubq_u8(indices, c51);
+            let gt25 = vcgtq_s8(vreinterpretq_s8_u8(indices), c25);
+            let reduced = vsubq_u8(reduced, gt25); // subtracting 0xFF adds 1 where index > 25
+            let ascii = vaddq_u8(indices, vqtbl1q_u8(translate, reduced));
+
+            // SAFETY: the loop guard ensures `output[o..o+16]` is in bounds, so this writes 16 bytes
+            // in bounds.
+            vst1q_u8(output.as_mut_ptr().add(o), ascii);
+            i += 12;
+            o += 16;
+        }
+        (i, o)
+    }
+
+    /// Decode leading whole 16-byte input blocks (16 in -> 12 out per iteration).
+    ///
+    /// # Safety
+    ///
+    /// The running CPU must support NEON.
+    #[target_feature(enable = "neon")]
+    pub(super) unsafe fn decode_bulk<A: SimdAlphabet>(
+        input: &[u8],
+        quads_end: usize,
+        output: &mut [u8],
+    ) -> (usize, usize) {
+        if quads_end < SIMD_MIN_INPUT_DECODE {
+            return (0, 0);
+        }
+        let shift_data = A::DECODE_SHIFT_LUT;
+        let mask_data = A::DECODE_MASK_LUT;
+        // SAFETY: each LUT is a 16-byte array read in full by `vld1q_u8`.
+        let shift_lut = vld1q_u8(shift_data.as_ptr().cast());
+        let mask_lut = vld1q_u8(mask_data.as_ptr());
+        let bitpos_lut = vld1q_u8(BITPOS_LUT.as_ptr());
+        let low_nibble_mask = vdupq_n_u8(0x0f);
+        let fixup_char_v = vdupq_n_u8(A::DECODE_FIXUP_CHAR as u8);
+        let fixup_shift_v = vdupq_n_u8(A::DECODE_FIXUP_SHIFT as u8);
+        let zero = vdupq_n_u8(0);
+        let mm1 = vdupq_n_u32(0x003f_003f);
+        let mm2 = vdupq_n_u32(0x3f00_3f00);
+        let out_mask = vdupq_n_u32(0x00ff_ffff);
+        let pack_bytes: [u8; 16] = [
+            2, 1, 0, 6, 5, 4, 10, 9, 8, 14, 13, 12, 0x80, 0x80, 0x80, 0x80,
+        ];
+        // SAFETY: `pack_bytes` is a 16-byte array read in full by `vld1q_u8`.
+        let pack_shuf = vld1q_u8(pack_bytes.as_ptr());
+
+        let mut i = 0usize;
+        let mut o = 0usize;
+        // Need 16 input bytes to load; writes exactly 12 output bytes.
+        while i + 16 <= quads_end && o + 12 <= output.len() {
+            // SAFETY: `i + 16 <= quads_end <= input.len()`, so this reads 16 in-bounds bytes.
+            let data = vld1q_u8(input.as_ptr().add(i));
+            let hi = vshrq_n_u8::<4>(data);
+            let lo = vandq_u8(data, low_nibble_mask);
+
+            let m = vqtbl1q_u8(mask_lut, lo);
+            let bit = vqtbl1q_u8(bitpos_lut, hi);
+            let non_match = vceqq_u8(vandq_u8(m, bit), zero);
+            if vmaxvq_u8(non_match) != 0 {
+                // Invalid byte in this block; let the scalar decoder report the exact offset.
+                break;
+            }
+
+            let sh = vqtbl1q_u8(shift_lut, hi);
+            let eq_fixup = vceqq_u8(data, fixup_char_v);
+            let shift = vbslq_u8(eq_fixup, fixup_shift_v, sh);
+            let values = vaddq_u8(data, shift); // {00aaaaaa|00bbbbbb|00cccccc|00dddddd} x4
+
+            // merge 4x6 bits -> 3 bytes per quad via shift/mask (no multiplies on NEON)
+            let v = vreinterpretq_u32_u8(values);
+            let x1 = vandq_u32(v, mm1); // {00aaaaaa|00000000|00cccccc|00000000}
+            let x2 = vandq_u32(v, mm2); // {00000000|00bbbbbb|00000000|00dddddd}
+            let x3 = vorrq_u32(vshlq_n_u32::<18>(x1), vshrq_n_u32::<10>(x1));
+            let x4 = vorrq_u32(vshlq_n_u32::<4>(x2), vshrq_n_u32::<24>(x2));
+            let merged = vandq_u32(vorrq_u32(x3, x4), out_mask);
+            let packed = vqtbl1q_u8(vreinterpretq_u8_u32(merged), pack_shuf); // 12 bytes in [0..12)
+
+            // Store exactly 12 bytes (8 + 4); a wider store would clobber an oversized output.
+            // SAFETY: the loop guard ensures `o + 12 <= output.len()`, so the 8-byte store at `o`
+            // and the 4-byte lane store at `o + 8` are both in bounds.
+            vst1_u8(output.as_mut_ptr().add(o), vget_low_u8(packed));
+            vst1q_lane_u32::<2>(
+                output.as_mut_ptr().add(o + 8).cast(),
+                vreinterpretq_u32_u8(packed),
+            );
+            i += 16;
+            o += 12;
+        }
+        (i, o)
+    }
+}
+
+/// Dispatch the AVX2 encode kernel to the right alphabet monomorphization.
+///
+/// # Safety
+///
+/// The running CPU must support AVX2 (the requirement is forwarded to [`avx2::encode_bulk`]).
+#[cfg(target_arch = "x86_64")]
+#[inline]
+unsafe fn avx2_encode(kind: SimdKind, input: &[u8], output: &mut [u8]) -> (usize, usize) {
+    match kind {
+        // SAFETY: this function's contract guarantees AVX2, which is all the kernel requires.
+        SimdKind::Standard => avx2::encode_bulk::<Standard>(input, output),
+        SimdKind::UrlSafe => avx2::encode_bulk::<UrlSafe>(input, output),
+    }
+}
+
+/// Dispatch the AVX2 decode kernel to the right alphabet monomorphization.
+///
+/// # Safety
+///
+/// The running CPU must support AVX2 (the requirement is forwarded to [`avx2::decode_bulk`]).
+#[cfg(target_arch = "x86_64")]
+#[inline]
+unsafe fn avx2_decode(
+    kind: SimdKind,
+    input: &[u8],
+    quads_end: usize,
+    output: &mut [u8],
+) -> (usize, usize) {
+    match kind {
+        // SAFETY: this function's contract guarantees AVX2, which is all the kernel requires.
+        SimdKind::Standard => avx2::decode_bulk::<Standard>(input, quads_end, output),
+        SimdKind::UrlSafe => avx2::decode_bulk::<UrlSafe>(input, quads_end, output),
+    }
+}
+
+/// Dispatch the NEON encode kernel to the right alphabet monomorphization.
+///
+/// # Safety
+///
+/// The running CPU must support NEON.
+#[cfg(target_arch = "aarch64")]
+#[inline]
+unsafe fn neon_encode(kind: SimdKind, input: &[u8], output: &mut [u8]) -> (usize, usize) {
+    match kind {
+        // SAFETY: this function's contract guarantees NEON, which is all the kernel requires.
+        SimdKind::Standard => neon::encode_bulk::<Standard>(input, output),
+        SimdKind::UrlSafe => neon::encode_bulk::<UrlSafe>(input, output),
+    }
+}
+
+/// Dispatch the NEON decode kernel to the right alphabet monomorphization.
+///
+/// # Safety
+///
+/// The running CPU must support NEON.
+#[cfg(target_arch = "aarch64")]
+#[inline]
+unsafe fn neon_decode(
+    kind: SimdKind,
+    input: &[u8],
+    quads_end: usize,
+    output: &mut [u8],
+) -> (usize, usize) {
+    match kind {
+        // SAFETY: this function's contract guarantees NEON, which is all the kernel requires.
+        SimdKind::Standard => neon::decode_bulk::<Standard>(input, quads_end, output),
+        SimdKind::UrlSafe => neon::decode_bulk::<UrlSafe>(input, quads_end, output),
+    }
+}
+
+/// Which instruction set an engine dispatches to.
+#[cfg(all(feature = "std", any(target_arch = "x86_64", target_arch = "aarch64")))]
+#[derive(Clone, Copy, Debug)]
+enum Backend {
+    Scalar,
+    #[cfg(target_arch = "x86_64")]
+    Avx2,
+    #[cfg(target_arch = "aarch64")]
+    Neon,
+}
+
+/// A base64 engine that uses the best SIMD instruction set detected at runtime, falling back to the
+/// scalar [`GeneralPurpose`] engine.
+///
+/// Requires the `std` feature (for runtime CPU-feature detection) and an `x86_64` or `aarch64`
+/// target. On other targets, use [`GeneralPurpose`] directly. Only the STANDARD and URL_SAFE
+/// alphabets are accelerated, so it is constructed with [`Simd::standard`] / [`Simd::url_safe`].
+#[cfg(all(feature = "std", any(target_arch = "x86_64", target_arch = "aarch64")))]
+#[derive(Debug, Clone)]
+pub struct Simd {
+    inner: GeneralPurpose,
+    kind: SimdKind,
+    backend: Backend,
+}
+
+#[cfg(all(feature = "std", any(target_arch = "x86_64", target_arch = "aarch64")))]
+impl Simd {
+    /// Create a `Simd` engine for the STANDARD alphabet, detecting the instruction set once.
+    #[must_use]
+    pub fn standard(config: GeneralPurposeConfig) -> Self {
+        Self::new(SimdKind::Standard, &crate::alphabet::STANDARD, config)
+    }
+
+    /// Create a `Simd` engine for the URL_SAFE alphabet, detecting the instruction set once.
+    #[must_use]
+    pub fn url_safe(config: GeneralPurposeConfig) -> Self {
+        Self::new(SimdKind::UrlSafe, &crate::alphabet::URL_SAFE, config)
+    }
+
+    fn new(
+        kind: SimdKind,
+        alphabet: &crate::alphabet::Alphabet,
+        config: GeneralPurposeConfig,
+    ) -> Self {
+        #[cfg(target_arch = "x86_64")]
+        let backend = if std::is_x86_feature_detected!("avx2") {
+            Backend::Avx2
+        } else {
+            Backend::Scalar
+        };
+        #[cfg(target_arch = "aarch64")]
+        let backend = if std::arch::is_aarch64_feature_detected!("neon") {
+            Backend::Neon
+        } else {
+            Backend::Scalar
+        };
+
+        Self {
+            inner: GeneralPurpose::new(alphabet, config),
+            kind,
+            backend,
+        }
+    }
+}
+
+#[cfg(all(feature = "std", any(target_arch = "x86_64", target_arch = "aarch64")))]
+impl Engine for Simd {
+    type Config = GeneralPurposeConfig;
+    type DecodeEstimate = GeneralPurposeEstimate;
+
+    fn internal_encode(&self, input: &[u8], output: &mut [u8]) -> usize {
+        let kind = self.kind;
+        match self.backend {
+            Backend::Scalar => self.inner.internal_encode(input, output),
+            #[cfg(target_arch = "x86_64")]
+            Backend::Avx2 => encode_helper(self.inner.encode_table(), input, output, |i, o| {
+                // SAFETY: the Avx2 backend is only selected when AVX2 was detected.
+                unsafe { avx2_encode(kind, i, o) }
+            }),
+            #[cfg(target_arch = "aarch64")]
+            Backend::Neon => encode_helper(self.inner.encode_table(), input, output, |i, o| {
+                // SAFETY: the Neon backend is only selected when NEON was detected.
+                unsafe { neon_encode(kind, i, o) }
+            }),
+        }
+    }
+
+    fn internal_decoded_len_estimate(&self, input_len: usize) -> Self::DecodeEstimate {
+        self.inner.internal_decoded_len_estimate(input_len)
+    }
+
+    fn internal_decode(
+        &self,
+        input: &[u8],
+        output: &mut [u8],
+        estimate: Self::DecodeEstimate,
+    ) -> Result<DecodeMetadata, DecodeSliceError> {
+        let kind = self.kind;
+        match self.backend {
+            Backend::Scalar => self.inner.internal_decode(input, output, estimate),
+            #[cfg(target_arch = "x86_64")]
+            Backend::Avx2 => decode_helper(
+                input,
+                &estimate,
+                output,
+                self.inner.decode_table(),
+                self.inner.config().decode_allow_trailing_bits(),
+                self.inner.config().decode_padding_mode(),
+                // SAFETY: the Avx2 backend is only selected when AVX2 was detected.
+                |i, end, o| unsafe { avx2_decode(kind, i, end, o) },
+            ),
+            #[cfg(target_arch = "aarch64")]
+            Backend::Neon => decode_helper(
+                input,
+                &estimate,
+                output,
+                self.inner.decode_table(),
+                self.inner.config().decode_allow_trailing_bits(),
+                self.inner.config().decode_padding_mode(),
+                // SAFETY: the Neon backend is only selected when NEON was detected.
+                |i, end, o| unsafe { neon_decode(kind, i, end, o) },
+            ),
+        }
+    }
+
+    fn config(&self) -> &Self::Config {
+        self.inner.config()
+    }
+}
+
+/// A base64 engine that unconditionally uses AVX2, without runtime detection.
+///
+/// This works in `no_std` builds. Because it does not check for AVX2 support, it must only be used
+/// on a CPU that has it. Only the STANDARD and URL_SAFE alphabets are accelerated, so it is
+/// constructed with the [`Avx2::standard`] / [`Avx2::url_safe`] (checked) or
+/// [`Avx2::standard_unchecked`] / [`Avx2::url_safe_unchecked`] constructors.
+#[cfg(target_arch = "x86_64")]
+#[derive(Debug, Clone)]
+pub struct Avx2 {
+    inner: GeneralPurpose,
+    kind: SimdKind,
+}
+
+#[cfg(target_arch = "x86_64")]
+impl Avx2 {
+    /// Create an `Avx2` engine for the STANDARD alphabet if the running CPU supports AVX2, else
+    /// `None`.
+    ///
+    /// Requires the `std` feature for the detection; in `no_std` use [`Avx2::standard_unchecked`].
+    #[cfg(feature = "std")]
+    #[must_use]
+    pub fn standard(config: GeneralPurposeConfig) -> Option<Self> {
+        if std::is_x86_feature_detected!("avx2") {
+            // SAFETY: AVX2 support was just verified.
+            Some(unsafe { Self::standard_unchecked(config) })
+        } else {
+            None
+        }
+    }
+
+    /// Create an `Avx2` engine for the URL_SAFE alphabet if the running CPU supports AVX2, else
+    /// `None`.
+    ///
+    /// Requires the `std` feature for the detection; in `no_std` use [`Avx2::url_safe_unchecked`].
+    #[cfg(feature = "std")]
+    #[must_use]
+    pub fn url_safe(config: GeneralPurposeConfig) -> Option<Self> {
+        if std::is_x86_feature_detected!("avx2") {
+            // SAFETY: AVX2 support was just verified.
+            Some(unsafe { Self::url_safe_unchecked(config) })
+        } else {
+            None
+        }
+    }
+
+    /// Create an `Avx2` engine for the STANDARD alphabet without checking for AVX2 support.
+    ///
+    /// # Safety
+    ///
+    /// The CPU that will run encode/decode must support AVX2. Using the engine on a CPU without
+    /// AVX2 is undefined behavior.
+    #[must_use]
+    pub const unsafe fn standard_unchecked(config: GeneralPurposeConfig) -> Self {
+        Self {
+            inner: GeneralPurpose::new(&crate::alphabet::STANDARD, config),
+            kind: SimdKind::Standard,
+        }
+    }
+
+    /// Create an `Avx2` engine for the URL_SAFE alphabet without checking for AVX2 support.
+    ///
+    /// # Safety
+    ///
+    /// The CPU that will run encode/decode must support AVX2. Using the engine on a CPU without
+    /// AVX2 is undefined behavior.
+    #[must_use]
+    pub const unsafe fn url_safe_unchecked(config: GeneralPurposeConfig) -> Self {
+        Self {
+            inner: GeneralPurpose::new(&crate::alphabet::URL_SAFE, config),
+            kind: SimdKind::UrlSafe,
+        }
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+impl Engine for Avx2 {
+    type Config = GeneralPurposeConfig;
+    type DecodeEstimate = GeneralPurposeEstimate;
+
+    fn internal_encode(&self, input: &[u8], output: &mut [u8]) -> usize {
+        let kind = self.kind;
+        encode_helper(self.inner.encode_table(), input, output, |i, o| {
+            // SAFETY: constructing this engine asserts AVX2 support.
+            unsafe { avx2_encode(kind, i, o) }
+        })
+    }
+
+    fn internal_decoded_len_estimate(&self, input_len: usize) -> Self::DecodeEstimate {
+        self.inner.internal_decoded_len_estimate(input_len)
+    }
+
+    fn internal_decode(
+        &self,
+        input: &[u8],
+        output: &mut [u8],
+        estimate: Self::DecodeEstimate,
+    ) -> Result<DecodeMetadata, DecodeSliceError> {
+        let kind = self.kind;
+        decode_helper(
+            input,
+            &estimate,
+            output,
+            self.inner.decode_table(),
+            self.inner.config().decode_allow_trailing_bits(),
+            self.inner.config().decode_padding_mode(),
+            // SAFETY: constructing this engine asserts AVX2 support.
+            |i, end, o| unsafe { avx2_decode(kind, i, end, o) },
+        )
+    }
+
+    fn config(&self) -> &Self::Config {
+        self.inner.config()
+    }
+}
+
+/// A base64 engine that unconditionally uses NEON, without runtime detection.
+///
+/// This engine is available on aarch64 targets compiled with NEON support and works in `no_std`.
+#[cfg(target_arch = "aarch64")]
+#[derive(Debug, Clone)]
+pub struct Neon {
+    inner: GeneralPurpose,
+    kind: SimdKind,
+}
+
+#[cfg(target_arch = "aarch64")]
+impl Neon {
+    /// Create a `Neon` engine for the STANDARD alphabet on a target compiled with NEON support.
+    #[must_use]
+    pub const fn standard(config: GeneralPurposeConfig) -> Self {
+        Self {
+            inner: GeneralPurpose::new(&crate::alphabet::STANDARD, config),
+            kind: SimdKind::Standard,
+        }
+    }
+
+    /// Create a `Neon` engine for the URL_SAFE alphabet on a target compiled with NEON support.
+    #[must_use]
+    pub const fn url_safe(config: GeneralPurposeConfig) -> Self {
+        Self {
+            inner: GeneralPurpose::new(&crate::alphabet::URL_SAFE, config),
+            kind: SimdKind::UrlSafe,
+        }
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+impl Engine for Neon {
+    type Config = GeneralPurposeConfig;
+    type DecodeEstimate = GeneralPurposeEstimate;
+
+    fn internal_encode(&self, input: &[u8], output: &mut [u8]) -> usize {
+        let kind = self.kind;
+        encode_helper(self.inner.encode_table(), input, output, |i, o| {
+            // SAFETY: this module is only compiled for targets with NEON enabled.
+            unsafe { neon_encode(kind, i, o) }
+        })
+    }
+
+    fn internal_decoded_len_estimate(&self, input_len: usize) -> Self::DecodeEstimate {
+        self.inner.internal_decoded_len_estimate(input_len)
+    }
+
+    fn internal_decode(
+        &self,
+        input: &[u8],
+        output: &mut [u8],
+        estimate: Self::DecodeEstimate,
+    ) -> Result<DecodeMetadata, DecodeSliceError> {
+        let kind = self.kind;
+        decode_helper(
+            input,
+            &estimate,
+            output,
+            self.inner.decode_table(),
+            self.inner.config().decode_allow_trailing_bits(),
+            self.inner.config().decode_padding_mode(),
+            // SAFETY: this module is only compiled for targets with NEON enabled.
+            |i, end, o| unsafe { neon_decode(kind, i, end, o) },
+        )
+    }
+
+    fn config(&self) -> &Self::Config {
+        self.inner.config()
+    }
+}
+
+#[cfg(all(
+    test,
+    any(target_arch = "x86_64", target_arch = "aarch64"),
+    feature = "std"
+))]
+mod tests {
+    use crate::{
+        alphabet::{self, Alphabet},
+        engine::{
+            general_purpose::PAD,
+            naive::{Naive, NaiveConfig},
+            DecodePaddingMode, Engine,
+        },
+    };
+    use rand::{rngs::SmallRng, Rng, SeedableRng};
+
+    fn naive(alphabet: &Alphabet) -> Naive {
+        Naive::new(
+            alphabet,
+            NaiveConfig {
+                encode_padding: true,
+                decode_allow_trailing_bits: false,
+                decode_padding_mode: DecodePaddingMode::RequireCanonical,
+            },
+        )
+    }
+
+    fn seeded_bytes(len: usize, seed: u64) -> Vec<u8> {
+        let mut rng = SmallRng::seed_from_u64(seed);
+        (0..len).map(|_| rng.gen()).collect()
+    }
+
+    /// Run every correctness check for one engine against the scalar `naive` oracle.
+    fn exercise<E: Engine>(name: &str, engine: &E, alphabet: &Alphabet) {
+        let oracle = naive(alphabet);
+
+        // Differential encode/decode over many lengths and seeds.
+        for len in 0..=400 {
+            for seed in 0..4u64 {
+                let data = seeded_bytes(len, 0x51D_0000 ^ (len as u64) << 3 ^ seed);
+                let encoded = engine.encode(&data);
+                assert_eq!(encoded, oracle.encode(&data), "{name} encode len {len}");
+                assert_eq!(
+                    engine.decode(&encoded).unwrap(),
+                    data,
+                    "{name} roundtrip {len}"
+                );
+            }
+        }
+
+        // Decode of every possible byte value at a range of positions (validity + decoded value).
+        let encoded = engine.encode(seeded_bytes(96, 0xA5A5_0001));
+        for b in 0u8..=255 {
+            for &pos in &[0usize, 5, 31, 32, 33, 64, 95, 120] {
+                let mut c = encoded.clone().into_bytes();
+                c[pos] = b;
+                assert_eq!(
+                    engine.decode(&c),
+                    oracle.decode(&c),
+                    "{name} byte {b:#x}@{pos}"
+                );
+            }
+        }
+
+        // Slice APIs must not write past the decoded/encoded length in an oversized buffer.
+        for len in [96usize, 120, 192, 300, 768, 3072] {
+            let data = seeded_bytes(len, 0xC10B_BE12 ^ len as u64);
+            let encoded = engine.encode(&data);
+
+            let mut out = vec![0xAB_u8; len + 64];
+            let written = engine.decode_slice(&encoded, &mut out).unwrap();
+            assert_eq!(written, len, "{name} decoded len at {len}");
+            assert_eq!(&out[..len], &data[..], "{name} decoded bytes at {len}");
+            assert!(
+                out[len..].iter().all(|&b| b == 0xAB),
+                "{} clobbered past decoded region at len {}",
+                name,
+                len
+            );
+
+            let mut out = vec![0xCD_u8; encoded.len() + 64];
+            let written = engine.encode_slice(&data, &mut out).unwrap();
+            assert_eq!(written, encoded.len(), "{name} encoded len at {len}");
+            assert_eq!(
+                &out[..written],
+                encoded.as_bytes(),
+                "{name} encoded bytes at {len}"
+            );
+            assert!(
+                out[written..].iter().all(|&b| b == 0xCD),
+                "{} clobbered past encoded region at len {}",
+                name,
+                len
+            );
+        }
+    }
+
+    #[test]
+    fn simd_engine_matches_scalar() {
+        exercise("simd std", &super::Simd::standard(PAD), &alphabet::STANDARD);
+        exercise("simd url", &super::Simd::url_safe(PAD), &alphabet::URL_SAFE);
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn avx2_engine_matches_scalar() {
+        if let Some(engine) = super::Avx2::standard(PAD) {
+            exercise("avx2 std", &engine, &alphabet::STANDARD);
+        }
+        if let Some(engine) = super::Avx2::url_safe(PAD) {
+            exercise("avx2 url", &engine, &alphabet::URL_SAFE);
+        }
+    }
+
+    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+    #[test]
+    fn neon_engine_matches_scalar() {
+        exercise("neon std", &super::Neon::standard(PAD), &alphabet::STANDARD);
+        exercise("neon url", &super::Neon::url_safe(PAD), &alphabet::URL_SAFE);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,6 +245,26 @@
 //! assert_eq!("base64: AAECAw==", format!("base64: {}", value));
 //! ```
 //!
+//! # Crate features
+//!
+//! - `std` (default): enables `std::io` integration, [`std::error::Error`] impls, and heap
+//!   allocation. Implies `alloc`.
+//! - `alloc`: enables the allocating APIs (e.g. [`Engine::encode`], [`Engine::decode`]) in a
+//!   `no_std` build.
+//! - `simd-unsafe`: enables the SIMD-accelerated engines. It is off by default and is the only
+//!   feature that introduces `unsafe` code; with it disabled the crate is
+//!   `#![forbid(unsafe_code)]`.
+//!
+//! ## SIMD acceleration
+//!
+//! With the `simd-unsafe` feature, the [`engine`] module provides SIMD engines for the standard and
+//! URL-safe alphabets that are several times faster than [`GeneralPurpose`][engine::GeneralPurpose]:
+//!
+//! - `Simd` picks the best available instruction set (AVX2 on `x86_64`, NEON on `aarch64`) at
+//!   runtime and falls back to the scalar engine. It needs `std` for the CPU-feature detection.
+//! - `Avx2` and `Neon` target one instruction set without runtime detection, so they can be used in
+//!   `no_std` builds when the target is known to support the instructions.
+//!
 //! # Panics
 //!
 //! If length calculations result in overflowing `usize`, a panic will result.
@@ -258,7 +278,11 @@
     unused_results,
     variant_size_differences
 )]
-#![forbid(unsafe_code)]
+// The `simd-unsafe` feature (off by default) is the only source of `unsafe`; without it the crate
+// is `#![forbid(unsafe_code)]`. When it is enabled, `unsafe` is confined to the SIMD engine module,
+// which opts back in with a localized `allow`.
+#![cfg_attr(not(feature = "simd-unsafe"), forbid(unsafe_code))]
+#![cfg_attr(feature = "simd-unsafe", deny(unsafe_code))]
 // Allow globally until https://github.com/rust-lang/rust-clippy/issues/8768 is resolved.
 // The desired state is to allow it only for the rstest_reuse import.
 #![allow(clippy::single_component_path_imports)]


### PR DESCRIPTION
Add SIMD-accelerated base64 for the STANDARD and URL_SAFE alphabets, controlled
by the `simd-unsafe` feature (on by default). It is the only feature that uses
`unsafe`; disabling it makes the crate `#![forbid(unsafe_code)]`. When enabled,
`unsafe` is confined to the SIMD module and the crate uses `#![deny(unsafe_code)]`.

Three engines are provided, all reusing the scalar `GeneralPurpose` kernels for
the tail and fallback:

- `Simd`: detects the best instruction set at runtime (AVX2 on x86_64, NEON on
  aarch64) and falls back to scalar. Needs `std` for the detection.

- `Avx2` / `Neon`: target one instruction set with no runtime detection, so they
  work in `no_std`. `Avx2` exposes a checked `new` (std) and an
  `unsafe new_unchecked`; NEON is mandatory on aarch64 so `Neon::new` is safe.

- `GeneralPurpose` stays a pure-scalar engine; the encode/decode helpers take an
  optional SIMD-prefix step that is a no-op for it.

Instruction counts below were gathered with gungraun (Callgrind); wall-clock
times with the criterion benchmarks (AVX2, x86-64-v3, this machine):

| Operation    | Input | Instructions (scalar -> SIMD)  | Wall-clock (scalar -> SIMD) |
| ------------ | ----- | ------------------------------ | --------------------------- |
| encode_slice | 3 KiB | 22,245 -> 4,741        (4.7x)  | 1.73 us -> 468 ns   (3.7x)  |
| encode_slice | 3 MiB | 22,282,621 -> 3,802,013 (5.9x) | 1.74 ms -> 456 us   (3.8x)  |
| decode_slice | 3 KiB | 28,620 -> 4,817        (5.9x)  | 1.49 us -> 230 ns   (6.5x)  |
| decode_slice | 3 MiB | 28,705,264 -> 4,063,989 (7.1x) | 1.54 ms -> 216 us   (7.1x)  |