### PR TITLE
Document no trailing trailing bits

### DIFF
--- a/src/engine/general_purpose/mod.rs
+++ b/src/engine/general_purpose/mod.rs
@@ -431,54 +431,78 @@ impl GeneralPurposeConfig {
 }
 
 /// A [`GeneralPurpose`] engine using the [`alphabet::STANDARD`] base64 alphabet and [`PAD`] config.
+///
+/// Does not allow trailing bits when decoding.
 pub const STANDARD: GeneralPurpose = GeneralPurpose::new(&alphabet::STANDARD, PAD);
 
 /// A [`GeneralPurpose`] engine using the [`alphabet::STANDARD`] base64 alphabet and
 /// [`PAD_INDIFFERENT`] config.
+///
+/// Does not allow trailing bits when decoding.
 pub const STANDARD_PAD_INDIFFERENT: GeneralPurpose =
     GeneralPurpose::new(&alphabet::STANDARD, PAD_INDIFFERENT);
 
 /// A [`GeneralPurpose`] engine using the [`alphabet::STANDARD`] base64 alphabet and [`NO_PAD`] config.
+///
+/// Does not allow trailing bits when decoding.
 pub const STANDARD_NO_PAD: GeneralPurpose = GeneralPurpose::new(&alphabet::STANDARD, NO_PAD);
 
 /// A [`GeneralPurpose`] engine using the [`alphabet::STANDARD`] base64 alphabet and
 /// [`NO_PAD_INDIFFERENT`] config.
+///
+/// Does not allow trailing bits when decoding.
 pub const STANDARD_NO_PAD_INDIFFERENT: GeneralPurpose =
     GeneralPurpose::new(&alphabet::STANDARD, NO_PAD_INDIFFERENT);
 
 /// A [`GeneralPurpose`] engine using the [`alphabet::URL_SAFE`] base64 alphabet and [`PAD`] config.
+///
+/// Does not allow trailing bits when decoding.
 pub const URL_SAFE: GeneralPurpose = GeneralPurpose::new(&alphabet::URL_SAFE, PAD);
 
 /// A [`GeneralPurpose`] engine using the [`alphabet::URL_SAFE`] base64 alphabet and
 /// [`PAD_INDIFFERENT`] config.
+///
+/// Does not allow trailing bits when decoding.
 pub const URL_SAFE_PAD_INDIFFERENT: GeneralPurpose =
     GeneralPurpose::new(&alphabet::URL_SAFE, PAD_INDIFFERENT);
 
 /// A [`GeneralPurpose`] engine using the [`alphabet::URL_SAFE`] base64 alphabet and [`NO_PAD`] config.
+///
+/// Does not allow trailing bits when decoding.
 pub const URL_SAFE_NO_PAD: GeneralPurpose = GeneralPurpose::new(&alphabet::URL_SAFE, NO_PAD);
 
 /// A [`GeneralPurpose`] engine using the [`alphabet::URL_SAFE`] base64 alphabet and
 /// [`NO_PAD_INDIFFERENT`] config.
+///
+/// Does not allow trailing bits when decoding.
 pub const URL_SAFE_NO_PAD_INDIFFERENT: GeneralPurpose =
     GeneralPurpose::new(&alphabet::URL_SAFE, NO_PAD_INDIFFERENT);
 
 /// Include padding bytes when encoding, and require that they be present when decoding.
+///
+/// Does not allow trailing bits when decoding.
 ///
 /// This is the standard per the base64 RFC, but consider using [`NO_PAD`] or [`NO_PAD_INDIFFERENT`]
 /// instead as padding serves little purpose in practice.
 pub const PAD: GeneralPurposeConfig = GeneralPurposeConfig::new();
 
 /// Include padding bytes when encoding, but allow input with or without padding when decoding.
+///
+/// Does not allow trailing bits when decoding.
 pub const PAD_INDIFFERENT: GeneralPurposeConfig = GeneralPurposeConfig::new()
     .with_encode_padding(true)
     .with_decode_padding_mode(DecodePaddingMode::Indifferent);
 
 /// Don't add padding when encoding, and require that there is no padding when decoding.
+///
+/// Does not allow trailing bits when decoding.
 pub const NO_PAD: GeneralPurposeConfig = GeneralPurposeConfig::new()
     .with_encode_padding(false)
     .with_decode_padding_mode(DecodePaddingMode::RequireNone);
 
 /// Don't add padding when encoding, and allow input with or without padding when decoding.
+///
+/// Does not allow trailing bits when decoding.
 pub const NO_PAD_INDIFFERENT: GeneralPurposeConfig = GeneralPurposeConfig::new()
     .with_encode_padding(false)
     .with_decode_padding_mode(DecodePaddingMode::Indifferent);

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3,6 +3,8 @@
 //! These are re-exports of `const` engines in [crate::engine::general_purpose], renamed with a `BASE64_`
 //! prefix for those who prefer to `use` the entire path to a name.
 //!
+//! All of these engine presets enforce no trailing bits when decoding.
+//!
 //! # Examples
 //!
 #![cfg_attr(feature = "alloc", doc = "```")]


### PR DESCRIPTION
Engine and config presets now document their no trailing bits state.

Fixes #289.