### PR TITLE
Fix testing on architectures without unsafe SIMD support

### DIFF
--- a/src/engine/tests.rs
+++ b/src/engine/tests.rs
@@ -2,7 +2,13 @@
 #![allow(unused_variables)]
 
 use crate::alphabet::Symbol;
-#[cfg(feature = "simd-unsafe")]
+#[cfg(all(
+    feature = "simd-unsafe",
+    any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", target_feature = "neon")
+    )
+))]
 use crate::engine::simd::Simd;
 #[cfg(all(
     feature = "simd-unsafe",
@@ -43,7 +49,16 @@ use std::{collections, fmt, io::Read as _};
 #[case::general_purpose(GeneralPurposeWrapper)]
 #[case::naive(NaiveWrapper)]
 #[case::decoder_reader(DecoderReaderEngineWrapper)]
-#[cfg_attr(feature = "simd-unsafe", case::simd(SimdEngineWrapper))]
+#[cfg_attr(
+    all(
+        feature = "simd-unsafe",
+        any(
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", target_feature = "neon")
+        )
+    ),
+    case::simd(SimdEngineWrapper)
+)]
 #[cfg_attr(
     all(
         feature = "simd-unsafe",
@@ -72,8 +87,26 @@ fn engines_supporting_arbitrary_alphabets<E: EngineWrapper>(#[case] engine_wrapp
 #[template]
 #[rstest]
 // so that there's at least one engine with no features enabled
-#[cfg_attr(not(feature = "simd-unsafe"), case::naive(NaiveWrapper))]
-#[cfg_attr(feature = "simd-unsafe", case::simd(SimdEngineWrapper))]
+#[cfg_attr(
+    not(all(
+        feature = "simd-unsafe",
+        any(
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", target_feature = "neon")
+        )
+    )),
+    case::naive(NaiveWrapper)
+)]
+#[cfg_attr(
+    all(
+        feature = "simd-unsafe",
+        any(
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", target_feature = "neon")
+        )
+    ),
+    case::simd(SimdEngineWrapper)
+)]
 #[cfg_attr(
     all(
         feature = "simd-unsafe",
@@ -105,7 +138,16 @@ enum CommonAlphabet {
 #[rstest]
 #[case::general_purpose(GeneralPurposeWrapper)]
 #[case::naive(NaiveWrapper)]
-#[cfg_attr(feature = "simd-unsafe", case::simd(SimdEngineWrapper))]
+#[cfg_attr(
+    all(
+        feature = "simd-unsafe",
+        any(
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", target_feature = "neon")
+        )
+    ),
+    case::simd(SimdEngineWrapper)
+)]
 #[cfg_attr(
     all(
         feature = "simd-unsafe",
@@ -1912,10 +1954,22 @@ impl EngineWrapper for DecoderReaderEngineWrapper {
     }
 }
 
-#[cfg(feature = "simd-unsafe")]
+#[cfg(all(
+    feature = "simd-unsafe",
+    any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", target_feature = "neon")
+    )
+))]
 struct SimdEngineWrapper;
 
-#[cfg(feature = "simd-unsafe")]
+#[cfg(all(
+    feature = "simd-unsafe",
+    any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", target_feature = "neon")
+    )
+))]
 impl EngineWrapper for SimdEngineWrapper {
     type Engine = Simd;
 


### PR DESCRIPTION
Fixes #309 by improving conditionals within `src/engine/tests.rs`.

This extends the basic approach from

https://github.com/marshallpierce/rust-base64/blob/e34f9a08c5c89a4641350ac22033f3fa4f5d4d97/src/engine/mod.rs#L17-L24

throughout the test code as needed to support testing on all architectures.

Particuarly, this ensures that the case where the `simd-unsafe` feature is enabled (as when default features are used), but  no unsafe SIMD implementation exists for the target, is always handled.