### PR TITLE
CI: build for ppc with miri

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,14 @@ jobs:
               cargo miri test --target aarch64-unknown-linux-gnu miri
             fi
       - run:
+          name: Test with miri ppc64 to ensure non-simd architectures build
+          # any architecture without SIMD implemented is fine for this
+          command: |
+            if [[ '<< parameters.toolchain_override >>' = 'nightly' ]]
+            then
+              cargo miri test --target powerpc64-unknown-linux-gnu miri
+            fi
+      - run:
           name: Test unsafe simd with miri x64 with tree borrows
           # enable non-runtime-detected simd
           environment:


### PR DESCRIPTION
This should avoid future issues like #309 where compile-time conditionals end up breaking the build for less common architectures.